### PR TITLE
Fix/25 fix header and union section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.4.0",
         "react-responsive": "^10.0.0",
         "react-router": "^7.1.5",
         "react-slick": "^0.30.3",
@@ -3113,6 +3114,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2623,6 +2623,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0",
     "react-responsive": "^10.0.0",
     "react-router": "^7.1.5",
     "react-slick": "^0.30.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "type-check": "tsc --noEmit",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/src/pages/Main/FarmSyetemNav/FarmSystemNav.styled.ts
+++ b/src/pages/Main/FarmSyetemNav/FarmSystemNav.styled.ts
@@ -45,34 +45,3 @@ export const Circle = styled.div<{ $isMobile: boolean }>`
   border-radius: 50%;
   margin-right: 6px;
 `;
-
-export const MobileNavbar = styled.div`
-  display: inline-flex;
-  height: 145px;
-  padding: 16px 19px 15px 19px;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  border-radius: 20px 0px 20px 20px;
-  border: 1px solid var(--FarmSystem_White, #FCFCFC);
-  background: var(--FarmSystem_Green01, #28723F);
-`;
-
-export const MobileNavItem = styled.a`
-  display: flex;
-  padding: 5px 0px;
-  align-items: center;
-  gap: 5px;
-  flex: 1 0 0;
-`;
-
-export const MobileNavText = styled.p`
-  color: var(--FarmSystem_White, #FCFCFC);
-  text-align: center;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 500;
-  line-height: 16px; /* 160% */
-  letter-spacing: -0.24px;
-`;

--- a/src/pages/Main/FarmSyetemNav/FarmSystemNav.styled.ts
+++ b/src/pages/Main/FarmSyetemNav/FarmSystemNav.styled.ts
@@ -8,8 +8,8 @@ interface FixedNavProps {
 export const FixedNavWrapper = styled.div<FixedNavProps>`
   position: fixed;
   top: ${({ isVisible, $isMobile }) =>
-    !$isMobile ? (isVisible ? "10px" : "-50px") :(isVisible ? "20px" : "-150px")};
-  right: 20px;
+    !$isMobile ? (isVisible ? "30px" : "-50px") :(isVisible ? "20px" : "-150px")};
+  right: ${({ $isMobile }) => ($isMobile ? "20px" : "50px")};
   transition: top 0.3s ease-in-out;
   z-index: 1000;
 `;

--- a/src/pages/Main/FarmSyetemNav/FarmSystemNav.styled.ts
+++ b/src/pages/Main/FarmSyetemNav/FarmSystemNav.styled.ts
@@ -7,11 +7,13 @@ interface FixedNavProps {
 
 export const FixedNavWrapper = styled.div<FixedNavProps>`
   position: fixed;
-  top: ${({ isVisible }) => (isVisible ? "10px" : "-50px")};
+  top: ${({ isVisible, $isMobile }) =>
+    !$isMobile ? (isVisible ? "10px" : "-50px") :(isVisible ? "20px" : "-150px")};
   right: 20px;
   transition: top 0.3s ease-in-out;
   z-index: 1000;
 `;
+
 
 export const Navbar = styled.nav<{ $isMobile: boolean }>`
   background-color: #216D35;
@@ -42,4 +44,35 @@ export const Circle = styled.div<{ $isMobile: boolean }>`
   background-color: white;
   border-radius: 50%;
   margin-right: 6px;
+`;
+
+export const MobileNavbar = styled.div`
+  display: inline-flex;
+  height: 145px;
+  padding: 16px 19px 15px 19px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 20px 0px 20px 20px;
+  border: 1px solid var(--FarmSystem_White, #FCFCFC);
+  background: var(--FarmSystem_Green01, #28723F);
+`;
+
+export const MobileNavItem = styled.a`
+  display: flex;
+  padding: 5px 0px;
+  align-items: center;
+  gap: 5px;
+  flex: 1 0 0;
+`;
+
+export const MobileNavText = styled.p`
+  color: var(--FarmSystem_White, #FCFCFC);
+  text-align: center;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 16px; /* 160% */
+  letter-spacing: -0.24px;
 `;

--- a/src/pages/Main/FarmSyetemNav/FarmSystemNav.tsx
+++ b/src/pages/Main/FarmSyetemNav/FarmSystemNav.tsx
@@ -1,21 +1,43 @@
 import * as S from './FarmSystemNav.styled';
 import { useState, useEffect } from 'react';
 import useMediaQueries from '@/hooks/useMediaQueries';
+import MobileNav from './MobileNav';
+
+const sectionIds = ["about", "tracks", "achievements", "eligibility"];
 
 export default function FarmSystemNav() {
   const [isVisible, setIsVisible] = useState(false);
   const { isMobile } = useMediaQueries();
+  const [currentSection, setCurrentSection] = useState("about");
 
   useEffect(() => {
     const handleScroll = () => {
-      if (window.scrollY > 200) {
+      const scrollPosition = window.scrollY;
+
+      if (scrollPosition > 200) {
         setIsVisible(true);
       } else {
         setIsVisible(false);
+      }      
+
+      // 현재 섹션 확인
+      for (const section of sectionIds) {
+        const element = document.getElementById(section);
+        if (element) {
+          const offsetTop = element.offsetTop;
+          const offsetBottom = offsetTop + element.offsetHeight;
+
+          if (scrollPosition >= offsetTop - 100 && scrollPosition < offsetBottom - 100) {
+            setCurrentSection(section);
+          }
+        }
       }
     };
 
+
     window.addEventListener("scroll", handleScroll);
+    handleScroll();
+
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
@@ -29,26 +51,17 @@ export default function FarmSystemNav() {
         top: targetElement.getBoundingClientRect().top + window.scrollY,
         behavior: "smooth",
       });
+      setCurrentSection(targetId);
     }
   };
 
   return (
     <S.FixedNavWrapper isVisible={isVisible} $isMobile={isMobile}>
       {isMobile ? (
-        <S.MobileNavbar>
-          <S.MobileNavItem href="#about" onClick={(e) => handleSmoothScroll(e, "#about")}>
-            <S.MobileNavText> Farm System이란?</S.MobileNavText>
-          </S.MobileNavItem>
-          <S.MobileNavItem href="#tracks" onClick={(e) => handleSmoothScroll(e, "#tracks")}>
-            <S.MobileNavText> 트랙 및 커리큘럼</S.MobileNavText>
-          </S.MobileNavItem>
-          <S.MobileNavItem href="#achievements" onClick={(e) => handleSmoothScroll(e, "#achievements")}>
-            <S.MobileNavText> 활동 및 성과</S.MobileNavText>
-          </S.MobileNavItem>
-          <S.MobileNavItem href="#eligibility" onClick={(e) => handleSmoothScroll(e, "#eligibility")}>
-            <S.MobileNavText> 지원 요건</S.MobileNavText>
-          </S.MobileNavItem>
-        </S.MobileNavbar>
+        <MobileNav 
+          currentSection={currentSection}
+          handleSmoothScroll={handleSmoothScroll}
+        />
       ) : (
         <S.Navbar $isMobile={isMobile}>
           <S.NavItem $isMobile={isMobile} href="#about" onClick={(e) => handleSmoothScroll(e, "#about")}>

--- a/src/pages/Main/FarmSyetemNav/FarmSystemNav.tsx
+++ b/src/pages/Main/FarmSyetemNav/FarmSystemNav.tsx
@@ -34,20 +34,37 @@ export default function FarmSystemNav() {
 
   return (
     <S.FixedNavWrapper isVisible={isVisible} $isMobile={isMobile}>
-      <S.Navbar $isMobile={isMobile}>
-        <S.NavItem $isMobile={isMobile} href="#about" onClick={(e) => handleSmoothScroll(e, "#about")}>
-          <S.Circle $isMobile={isMobile} /> Farm System이란?
-        </S.NavItem>
-        <S.NavItem $isMobile={isMobile} href="#tracks" onClick={(e) => handleSmoothScroll(e, "#tracks")}>
-          <S.Circle $isMobile={isMobile} /> 트랙 및 커리큘럼
-        </S.NavItem>
-        <S.NavItem $isMobile={isMobile} href="#achievements" onClick={(e) => handleSmoothScroll(e, "#achievements")}>
-          <S.Circle $isMobile={isMobile} /> 활동 및 성과
-        </S.NavItem>
-        <S.NavItem $isMobile={isMobile} href="#eligibility" onClick={(e) => handleSmoothScroll(e, "#eligibility")}>
-          <S.Circle $isMobile={isMobile} /> 지원 요건
-        </S.NavItem>
-      </S.Navbar>
+      {isMobile ? (
+        <S.MobileNavbar>
+          <S.MobileNavItem href="#about" onClick={(e) => handleSmoothScroll(e, "#about")}>
+            <S.MobileNavText> Farm System이란?</S.MobileNavText>
+          </S.MobileNavItem>
+          <S.MobileNavItem href="#tracks" onClick={(e) => handleSmoothScroll(e, "#tracks")}>
+            <S.MobileNavText> 트랙 및 커리큘럼</S.MobileNavText>
+          </S.MobileNavItem>
+          <S.MobileNavItem href="#achievements" onClick={(e) => handleSmoothScroll(e, "#achievements")}>
+            <S.MobileNavText> 활동 및 성과</S.MobileNavText>
+          </S.MobileNavItem>
+          <S.MobileNavItem href="#eligibility" onClick={(e) => handleSmoothScroll(e, "#eligibility")}>
+            <S.MobileNavText> 지원 요건</S.MobileNavText>
+          </S.MobileNavItem>
+        </S.MobileNavbar>
+      ) : (
+        <S.Navbar $isMobile={isMobile}>
+          <S.NavItem $isMobile={isMobile} href="#about" onClick={(e) => handleSmoothScroll(e, "#about")}>
+            <S.Circle $isMobile={isMobile} /> Farm System이란?
+          </S.NavItem>
+          <S.NavItem $isMobile={isMobile} href="#tracks" onClick={(e) => handleSmoothScroll(e, "#tracks")}>
+            <S.Circle $isMobile={isMobile} /> 트랙 및 커리큘럼
+          </S.NavItem>
+          <S.NavItem $isMobile={isMobile} href="#achievements" onClick={(e) => handleSmoothScroll(e, "#achievements")}>
+            <S.Circle $isMobile={isMobile} /> 활동 및 성과
+          </S.NavItem>
+          <S.NavItem $isMobile={isMobile} href="#eligibility" onClick={(e) => handleSmoothScroll(e, "#eligibility")}>
+            <S.Circle $isMobile={isMobile} /> 지원 요건
+          </S.NavItem>
+        </S.Navbar>
+      )}
     </S.FixedNavWrapper>
   );
 }

--- a/src/pages/Main/FarmSyetemNav/MobileNav.styled.ts
+++ b/src/pages/Main/FarmSyetemNav/MobileNav.styled.ts
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+export const MobileNavbar = styled.div<{ isNavOpen: boolean }>`
+  max-height: ${({ isNavOpen }) => (isNavOpen ? "300px" : "80px")};
+  overflow: hidden;
+  transition: max-height 0.1s ease-in-out;
+
+  display: inline-flex;
+  height: auto;
+  padding: 10px 10px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 150px;
+
+  border-radius: 20px 0px 20px 20px;
+  border: 1px solid var(--FarmSystem_White, #FCFCFC);
+  background: var(--FarmSystem_Green01, #28723F);
+`;
+
+export const MobileNavItem = styled.a`
+  display: flex;
+  padding: 5px 0px;
+  align-items: center;
+  gap: 3px;
+  flex: 1 0 0;
+`;
+
+export const MobileNavText = styled.p`
+  color: var(--FarmSystem_White, #FCFCFC);
+  text-align: center;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 16px;
+  letter-spacing: -0.24px;
+`;
+
+/* 확장/축소 버튼 스타일 */
+export const ExpandButton = styled.button`
+  color: var(--FarmSystem_White, #FCFCFC);
+  font-size: 24px;
+  cursor: pointer;
+  width: 80%;
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 15px; 
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/pages/Main/FarmSyetemNav/MobileNav.tsx
+++ b/src/pages/Main/FarmSyetemNav/MobileNav.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import * as S from './MobileNav.styled';
+import { IoMdArrowDropdown, IoMdArrowDropup } from "react-icons/io";
+
+interface MobileNavProps {
+  currentSection: string;
+  handleSmoothScroll: (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    targetId: string
+  ) => void;
+}
+
+const navItems = [
+  { id: "about", text: "Farm System이란?" },
+  { id: "tracks", text: "트랙 및 커리큘럼" },
+  { id: "achievements", text: "활동 및 성과" },
+  { id: "eligibility", text: "지원 요건" },
+];
+
+export default function MobileNav({ currentSection, handleSmoothScroll }: MobileNavProps) {
+  const [isNavOpen, setIsNavOpen] = useState(false);
+  const currentNavItem = navItems.find(item => item.id === currentSection) ?? navItems[0];
+
+  return (
+    <S.MobileNavbar isNavOpen={isNavOpen}>
+      {/* 
+        isNavOpen이 false면 첫 번째 메뉴만 보이게, 
+        true면 모든 메뉴가 보이게 설정 
+      */}
+      {!isNavOpen && (
+        <S.MobileNavItem
+          href={"#" + currentNavItem.id}
+          onClick={(e) => handleSmoothScroll(e, currentNavItem.id)}
+        >
+          <S.MobileNavText>{currentNavItem.text}</S.MobileNavText>
+        </S.MobileNavItem>
+      )}
+
+      {isNavOpen && (
+        <>
+          <S.MobileNavItem
+            href="#about"
+            onClick={(e) => handleSmoothScroll(e, "#about")}
+          >
+            <S.MobileNavText>Farm System이란?</S.MobileNavText>
+          </S.MobileNavItem>
+          <S.MobileNavItem
+            href="#tracks"
+            onClick={(e) => handleSmoothScroll(e, "#tracks")}
+          >
+            <S.MobileNavText>트랙 및 커리큘럼</S.MobileNavText>
+          </S.MobileNavItem>
+          <S.MobileNavItem
+            href="#achievements"
+            onClick={(e) => handleSmoothScroll(e, "#achievements")}
+          >
+            <S.MobileNavText>활동 및 성과</S.MobileNavText>
+          </S.MobileNavItem>
+          <S.MobileNavItem
+            href="#eligibility"
+            onClick={(e) => handleSmoothScroll(e, "#eligibility")}
+          >
+            <S.MobileNavText>지원 요건</S.MobileNavText>
+          </S.MobileNavItem>
+        </>
+      )}
+
+      {/* 확장/축소 버튼 */}
+      <S.ExpandButton onClick={() => setIsNavOpen((prev) => !prev)}>
+        {isNavOpen ? <IoMdArrowDropup /> : <IoMdArrowDropdown />}
+      </S.ExpandButton>
+    </S.MobileNavbar>
+  );
+}

--- a/src/pages/Main/Union/ContentBox.styled.ts
+++ b/src/pages/Main/Union/ContentBox.styled.ts
@@ -61,20 +61,21 @@ export const ContentInfoTextBox = styled.div<{ $isMobile: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  text-align: center;
+  text-align: ${(props) => (props.$isMobile ? "start" : "center")};
 
   margin-bottom: 35px;
   padding-top: ${(props) => (props.$isMobile ? "20px" : "0")};
   padding-bottom: ${(props) => (props.$isMobile ? "20px" : "0")};
 `;
 
-export const HighlightOrange = styled.span`
+export const HighlightOrange = styled.span<{ $isMobile: boolean }>`
   font-weight: 700;
   color: var(--FarmSystem_Orange);
+  margin-left: ${(props) => (props.$isMobile ? "10px" : "0")};
 `;
 
 export const ActivityTitle = styled.h3<{ $isMobile: boolean }>`
-  width: ${(props) => (props.$isMobile ? "auto" : "149px")};
+  width: ${(props) => (props.$isMobile ? "100%" : "149px")};
   height: ${(props) => (props.$isMobile ? "auto" : "38px")};
 
   font-weight: 700;
@@ -90,12 +91,12 @@ export const ActivityTitle = styled.h3<{ $isMobile: boolean }>`
   margin-bottom: ${(props) => (props.$isMobile ? "7px" : "17px")};
 `;
 
-export const ActivityList = styled.ul<{ $isMobile: boolean }>`
+export const ActivityList = styled.ul<{ $isMobile: boolean; $isTiny: boolean; }>`
   width: ${(props) => (props.$isMobile ? "90%" : "577px")};
   height: ${(props) => (props.$isMobile ? "auto" : "80px")};
 
   display: flex;
-  flex-direction: row;
+  flex-direction: ${(props) => (props.$isTiny ? "col" : "row")};
   flex-wrap: wrap;
   align-items: flex-end;
   align-content: flex-start;
@@ -122,15 +123,12 @@ export const Li = styled.li<{
   line-height: ${(props) => (props.$isMobile ? "30px" : "35px")};
   color: var(--FarmSystem_Black);
 
-  list-style-type: ${(props) =>
-    props.$isMobile && props.$isTiny ? "none" : "disc"};
+  list-style-type: disc;
   list-style-position: ${(props) =>
     props.$isMobile && props.$isTiny ? "none" : "outside"};
   margin-left: ${(props) =>
     props.$isMobile
-      ? props.$isTiny
-        ? "0px"
-        : "20px"
+      ? "20px"
       : "40px"};
   text-align: center;
 `;

--- a/src/pages/Main/Union/ContentBox.styled.ts
+++ b/src/pages/Main/Union/ContentBox.styled.ts
@@ -31,7 +31,7 @@ export const ContentBoxBorder = styled.div<{ $isMobile: boolean }>`
   justify-content: center;
   align-items: center;
   z-index: 10;
-  margin: 0 auto;
+  margin: 0 auto;  
 `;
 
 export const Content = styled.div<{ $isMobile: boolean }>`
@@ -134,16 +134,20 @@ export const GradientContainer = styled.div<{ $isMobile: boolean }>`
   position: absolute;
   top: 0;
   height: 500px;
+
+  //높이 문제로 정상적으로 진행 못했던 것 같아서 모바일 뷰로 처리해서 해결 했습니다.
+  height: ${(props) => (props.$isMobile ? "330px" : "500px")};
+
   // 배경 Gradient를 모바일에서도 보이게 하려면 이 부분 고쳐주시면 됩니다!
-  display: ${(props) => (props.$isMobile ? "none" : "flex")};
+  display: flex;
   gap: 80px;
   justify-content: center;
   align-items: center;
 `;
 
 export const GradientLeft = styled.div<{ $isMobile: boolean }>`
-  width: ${(props) => (props.$isMobile ? "300px" : "560px")};
-  height: ${(props) => (props.$isMobile ? "250px" : "400px")};
+  width: ${(props) => (props.$isMobile ? "240px" : "560px")};
+  height: ${(props) => (props.$isMobile ? "200px" : "400px")};
 
   background: linear-gradient(
     270deg,
@@ -155,8 +159,8 @@ export const GradientLeft = styled.div<{ $isMobile: boolean }>`
 `;
 
 export const GradientRight = styled.div<{ $isMobile: boolean }>`
-  width: ${(props) => (props.$isMobile ? "300px" : "560px")};
-  height: ${(props) => (props.$isMobile ? "250px" : "400px")};
+  width: ${(props) => (props.$isMobile ? "240px" : "560px")};
+  height: ${(props) => (props.$isMobile ? "200px" : "400px")};
   
   background: linear-gradient(
     90deg,

--- a/src/pages/Main/Union/ContentBox.styled.ts
+++ b/src/pages/Main/Union/ContentBox.styled.ts
@@ -34,7 +34,7 @@ export const ContentBoxBorder = styled.div<{ $isMobile: boolean }>`
   margin: 0 auto;
 `;
 
-export const Content = styled.div`
+export const Content = styled.div<{ $isMobile: boolean }>`
   width: 100%;
   height: 100%;
 
@@ -46,6 +46,8 @@ export const Content = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
+  padding: ${(props) => (props.$isMobile ? "0 5px" : "0")};
 `;
 
 export const ContentInfoTextBox = styled.div<{ $isMobile: boolean }>`
@@ -55,15 +57,15 @@ export const ContentInfoTextBox = styled.div<{ $isMobile: boolean }>`
   color: var(--FarmSystem_Black);
   font-style: normal;
   font-weight: 500;
-  font-size: ${(props) => (props.$isMobile ? "20px" : "24px")};
-  line-height: ${(props) => (props.$isMobile ? "30px" : "35px")};
+  font-size: ${(props) => (props.$isMobile ? "16px" : "24px")};
+  line-height: ${(props) => (props.$isMobile ? "28px" : "35px")};
   
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: ${(props) => (props.$isMobile ? "start" : "center")};
 
-  margin-bottom: 35px;
+  margin-bottom:  ${(props) => (props.$isMobile ? "13px" : "35px")};
   padding-top: ${(props) => (props.$isMobile ? "20px" : "0")};
   padding-bottom: ${(props) => (props.$isMobile ? "20px" : "0")};
 `;
@@ -96,14 +98,13 @@ export const ActivityList = styled.ul<{ $isMobile: boolean; $isTiny: boolean; }>
   height: ${(props) => (props.$isMobile ? "auto" : "80px")};
 
   display: flex;
-  flex-direction: ${(props) => (props.$isTiny ? "col" : "row")};
+  flex-direction: row;
   flex-wrap: wrap;
   align-items: flex-end;
   align-content: flex-start;
 
-  gap: ${(props) => (props.$isMobile ? "1px 10px" : "10px 20px")};
+  gap: ${(props) => (props.$isMobile ? "0 10px" : "10px 20px")};
   list-style-type: disc;
-  justify-content: ${(props) => (props.$isMobile ? "center" : "initial")};
 `;
 
 export const Li = styled.li<{
@@ -115,11 +116,7 @@ export const Li = styled.li<{
   font-style: normal;
   font-weight: 500;
   font-size: ${(props) =>
-    props.$isMobile
-      ? props.$isTiny
-        ? "16px"
-        : "18px"
-      : "22px"};
+    props.$isMobile ? "13px" : "22px"};
   line-height: ${(props) => (props.$isMobile ? "30px" : "35px")};
   color: var(--FarmSystem_Black);
 
@@ -128,7 +125,7 @@ export const Li = styled.li<{
     props.$isMobile && props.$isTiny ? "none" : "outside"};
   margin-left: ${(props) =>
     props.$isMobile
-      ? "20px"
+      ? "15px"
       : "40px"};
   text-align: center;
 `;

--- a/src/pages/Main/Union/ContentBox.tsx
+++ b/src/pages/Main/Union/ContentBox.tsx
@@ -13,19 +13,26 @@ export default function ContentBox() {
       <S.ContentBoxBorder $isMobile={isMobile}>
         <S.Content>
           <S.ContentInfoTextBox $isMobile={isMobile}>
-            <p>
-              <S.HighlightOrange>Union</S.HighlightOrange>은
-            </p>
-            <p>SW/AI 기초 역량을 다지기 위한 과정으로,</p>
-            <p>트랙 구분 없이 다섯 가지 트랙의 다양한 주제에 대한</p>
-            <p>SW 기본 역량을 다집니다.</p>
-            <p>각 트랙의 멘토가 제공하는 프로젝트와 스터디에</p>
-            <p>멘티로서 참여하게 됩니다.</p>
+          {isMobile ? (
+              <p><S.HighlightOrange $isMobile={isMobile}>Union</S.HighlightOrange>은 SW/AI 기초 역량을 다지기 위한 과정으로, 트랙 구분 없이 다섯 가지 트랙의 다양한 주제에 대한 SW 기본 역량을 다집니다. 각 트랙의 멘토가 제공하는 프로젝트와 스터디에 멘티로서 참여하게 됩니다.</p>
+            ) : (
+              <>
+                <p>
+                  <S.HighlightOrange $isMobile={isMobile}>Union</S.HighlightOrange>은
+                </p>
+                <p>SW/AI 기초 역량을 다지기 위한 과정으로,</p>
+                <p>트랙 구분 없이 다섯 가지 트랙의 다양한 주제에 대한</p>
+                <p>SW 기본 역량을 다집니다.</p>
+                <p>각 트랙의 멘토가 제공하는 프로젝트와 스터디에</p>
+                <p>멘티로서 참여하게 됩니다.</p>
+              </>
+            )}
+            
           </S.ContentInfoTextBox>
           <S.ActivityTitle $isMobile={isMobile}>
             한 학기 활동
           </S.ActivityTitle>
-          <S.ActivityList $isMobile={isMobile}>
+          <S.ActivityList $isMobile={isMobile} $isTiny={isTiny}>
             <S.Li $isMobile={isMobile} $isTiny={isTiny}>
               월별 기술 블로그
             </S.Li>

--- a/src/pages/Main/Union/ContentBox.tsx
+++ b/src/pages/Main/Union/ContentBox.tsx
@@ -11,7 +11,7 @@ export default function ContentBox() {
         <S.GradientRight $isMobile={isMobile} />
       </S.GradientContainer>
       <S.ContentBoxBorder $isMobile={isMobile}>
-        <S.Content>
+        <S.Content $isMobile={isMobile}>
           <S.ContentInfoTextBox $isMobile={isMobile}>
           {isMobile ? (
               <p><S.HighlightOrange $isMobile={isMobile}>Union</S.HighlightOrange>은 SW/AI 기초 역량을 다지기 위한 과정으로, 트랙 구분 없이 다섯 가지 트랙의 다양한 주제에 대한 SW 기본 역량을 다집니다. 각 트랙의 멘토가 제공하는 프로젝트와 스터디에 멘티로서 참여하게 됩니다.</p>
@@ -41,10 +41,10 @@ export default function ContentBox() {
             </S.Li>
             <S.Li $isMobile={isMobile} $isTiny={isTiny}>
               스터디 정기 모임
-            </S.Li>
+            </S.Li>            
             <S.Li $isMobile={isMobile} $isTiny={isTiny}>
               트랙 멘토-멘티 프로그램
-            </S.Li>
+            </S.Li>            
           </S.ActivityList>
         </S.Content>
       </S.ContentBoxBorder>

--- a/src/pages/Main/Union/Union.styled.ts
+++ b/src/pages/Main/Union/Union.styled.ts
@@ -33,7 +33,7 @@ export const UnionTextContainer = styled.div<{ $isMobile: boolean }>`
   align-items: start;
 
   width: ${(props) => (props.$isMobile ? "220px" : "300px")};
-  margin-bottom: ${(props) => (props.$isMobile ? "30px" : "50px")};
+  margin-bottom: ${(props) => (props.$isMobile ? "0" : "50px")};
 `;
 
 export const UnionText = styled.h2<{ $isMobile: boolean }>`


### PR DESCRIPTION
## #️⃣연관된 이슈

- #25 

## 📝작업 내용

- 모바일 목차 따로 만들고 조건부 렌더링
- 데스크탑 목차 위치 조정하기
- Union 섹션 글 모바일 상태에서 줄바꿈 조정하기
- Union 섹션 뒷배경 그래디언트 모바일에서도 살리기 + 미묘하게 조정해보기


## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [x] UI/UX 디자인 적용 확인

## 스크린샷

<img width="1710" alt="스크린샷 2025-02-16 오후 3 35 54" src="https://github.com/user-attachments/assets/eb828f73-49dc-4ea7-9c11-259cbaa1139a" />

- 데스크탑에서 헤더 위치 좀더 안쪽으로 밀었는데 피드백 주시면 좋을거 같습니다!
 <br>

| 접기 | 펼치기 |
|:---:|:---:|
| <img width="609" alt="스크린샷 2025-02-16 오후 3 36 44" src="https://github.com/user-attachments/assets/ea6bd964-2330-4394-aba5-5fddfdaa4785" /> | <img width="609" alt="스크린샷 2025-02-16 오후 3 37 19" src="https://github.com/user-attachments/assets/8aa4389b-23e6-45d7-a856-75704ccafbc2" /> |

- 피그마대로 모바일 헤더를 만들어 추가했습니다.
- 모바일에서 헤더가 너무 큰 공간을 차지하는거 같아 접기/펼치기를 추가해봤습니다.
    - 이 부분은 더 불편하다던가 거슬리면 삭제하겠습니다!
 <br>

<img width="609" alt="스크린샷 2025-02-16 오후 3 38 56" src="https://github.com/user-attachments/assets/3d2dda5d-3177-4b92-bfe5-8033f32fb81e" />

- 내부 설명 텍스트 줄바꿈을 모바일에선 없애고, 아래 활동 목록도 2줄로 잘 보이게 수정했습니다.
- 뒷배경 그래디언트를 모바일에서 보이게 하는 부분은 동민님이 도와주셨습니다!