### PR TITLE
chore: git push 시 Personal Access Token 사용하도록 Actions 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Push changes to forked repo
         run: |
-          git push -f forked-repo ${{ env.TARGET_BRANCH }}
+          git push -f https://$GITHUB_ACTOR:${{ secrets.AUTO_ACTIONS }}@github.com/DguFarmSystem/HomePage-FE.git ${{ env.TARGET_BRANCH }}
 
       - name: Clean up
         run: |


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71 

## 📝작업 내용

> git push 시 Personal Access Token 사용하도록 Actions 수정했습니다.

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
