### PR TITLE
fix: FAQ 페이지 폰트 적용 문제 수정

### DIFF
--- a/src/pages/FAQ/Question.styled.ts
+++ b/src/pages/FAQ/Question.styled.ts
@@ -65,7 +65,6 @@ export const FarmContainer = styled.div`
   width: 100%;
   font-size: 16px;
   color: #000;
-  font: prettendard-variable;
 `;
 
 export const P = styled.p`

--- a/src/pages/FAQ/index.styled.ts
+++ b/src/pages/FAQ/index.styled.ts
@@ -7,11 +7,10 @@ export const FAQContainer = styled.div`
   overflow-y: auto;
   text-align: center;
   color: #28723f;
-  font-family: 'Pretendard Variable';
 `;
 
 export const Title = styled.b<{ $isApp: boolean; $isMobile: boolean; $isTablet: boolean }>`
-  weight: 700;
+  font-weight: 700;
   display: block;
   margin-top: 170px;
   margin-bottom: ${({ $isMobile }) => ($isMobile ? '20px' : '50px')};

--- a/src/pages/Main/BottomInfo/BottomInfo.styles.ts
+++ b/src/pages/Main/BottomInfo/BottomInfo.styles.ts
@@ -14,7 +14,7 @@ export const Title = styled.h2<{ $isApp: boolean; $isMobile: boolean; $isTablet:
   color: #191919;
   font-weight: bold;
   text-align: center;
-  margin top: 20px;
+  margin-top: 20px;
   padding-bottom: 50px; 
 `;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #85 

## 📝작업 내용

- 특정 `styled-components` 내용에 폰트 선언 부분 삭제
- 원인은 잘 모르지만, 전체에서 한번 적용시킨 후 다시 선언하니 폰트가 적용이 안되는거 같습니다. 추후 스타일링 하실 때 `font-family` 옵션은 프리텐다드 베리어블이 아닌 폰트에만 써주시면 좋을거 같습니다...

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [x] UI/UX 디자인 적용 확인

## 스크린샷

| 기존 배포 페이지 | 수정본 |
|:---:|:---:|
| ![Image](https://github.com/user-attachments/assets/3d3e9fd8-67b5-44e9-af78-08a9f17543ad) | ![Image](https://github.com/user-attachments/assets/e4090404-56a9-4bde-8733-5bdbbfe99220) |

