### PR TITLE
fix: 팝업창 테두리 삭제 및 팝업 닫기 버튼 폰트사이즈/width 축소

### DIFF
--- a/src/components/Popup/Popup.styled.tsx
+++ b/src/components/Popup/Popup.styled.tsx
@@ -13,8 +13,7 @@ export const PopupOverlay = styled.div`
 export const PopupBox = styled.div<{ $isMobile: boolean; $isTablet: boolean }>`
   width: ${({ $isMobile, $isTablet }) => ($isMobile ? "300px" : $isTablet ? "420px" : "500px")};
   background-color: #fcfcfc;
-  border-radius: 15px;
-  border: 3px solid #28723f; 
+  border-radius: 15px; 
   text-align: center;
   padding: ${({ $isMobile }) => ($isMobile ? "30px" : "40px")};
   z-index: 10000;
@@ -37,14 +36,13 @@ export const PopupText = styled.p<{ $isMobile: boolean; $isTablet: boolean }>`
 export const PopupCloseButton = styled.button<{ $isMobile: boolean; $isTablet: boolean }>`
   background-color: #28723f;
   color: #fcfcfc;
-  font-size: 16px;
-  padding: 10px 20px;
+  font-size: ${({ $isMobile, $isTablet }) => ($isMobile ? "12px" : $isTablet ? "16px": "16px")};
   padding: ${({ $isMobile, $isTablet }) => ($isMobile ? "12px 24px" : $isTablet ? "12px 24px": "10px 20px")};
   border: none;
   border-radius: 10px;
   cursor: pointer;
   box-shadow: 0px 2px 10px rgba(25, 25, 25, 0.2);
-  width: 100px;
+  width: ${({ $isMobile, $isTablet }) => ($isMobile ? "80px" : $isTablet ? "100px": "100px")};
   margin-top: 20px;
   &:hover {
     background-color: #1f5b30;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) 팝업 테두리 삭제, 반응형 크기 수정을 메인에 반영

## 📝작업 내용

> 팝업 테두리 삭제, 반응형 크기 수정

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
<img width="260" alt="스크린샷 2025-02-27 오후 8 51 24" src="https://github.com/user-attachments/assets/bcfbb74a-238d-474b-8361-04b1ac323652" />

