### PR TITLE
fix: 프로젝트/블로그 페이지 분할 화면 깨짐 현상 해결

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,7 +7,7 @@ import NotFound from '@/pages/NotFound';
 import FAQ from '@/pages/FAQ';
 import MaintainPage from '@/pages/MaintainPage'
 
-const IS_MAINTENANCE = true; // 유지보수 모드 ON/OFF 설정은 여기서 해주시면 됩니다.
+const IS_MAINTENANCE = false; // 유지보수 모드 ON/OFF 설정은 여기서 해주시면 됩니다.
 
 export default function Router() {
   if (IS_MAINTENANCE) {

--- a/src/pages/Blog/BlogList.styles.tsx
+++ b/src/pages/Blog/BlogList.styles.tsx
@@ -57,6 +57,8 @@ export const TextContainer = styled.div<{$isMobile: boolean;}>`
   color: black;
   font-size: ${(props) => (props.$isMobile ? "20px" : "32px")};
   font-weight: 600;
+  margin-bottom: 200px;
+
 
   a {
     font-size: ${(props) => (props.$isMobile ? "10px" : "14px")};

--- a/src/pages/Blog/ProjectList.styles.tsx
+++ b/src/pages/Blog/ProjectList.styles.tsx
@@ -14,7 +14,6 @@ export const TableContainer = styled.div<{$isMobile: boolean; $isTablet: boolean
   display: flex;
   gap: 30px;
   width: 100%;
-  height: 10vh;
   justify-content: flex-start;
   margin-top: ${(props) => (props.$isMobile ? '0px' : props.$isTablet ? '15px' : '60px')};
 `;
@@ -41,7 +40,7 @@ export const FilterGradeButton = styled.button<{$isMobile: boolean; $isTablet: b
   justify-content: space-between;
   font-size: ${(props) => (props.$isMobile ? '12px' : props.$isTablet ? '14px' : '16px')};
   font-weight: 500;
-  width: ${(props) => (props.$isMobile ? '60px' : props.$isTablet ? '70px' : '80px')}; /* 기수 버튼은 작게 */
+  width: ${(props) => (props.$isMobile ? '80px' : props.$isTablet ? '70px' : '80px')}; /* 기수 버튼은 작게 */
 `;
 
 /** 트랙 버튼 */
@@ -64,7 +63,7 @@ export const DropdownGradeMenu = styled.div<{$isMobile: boolean; $isTablet: bool
   position: absolute;
   top: 45px;
   left: 0;
-  width: ${(props) => (props.$isMobile ? '60px' : props.$isTablet ? '70px' : '80px')}; /* 기수 버튼과 동일한 크기 */
+  width: ${(props) => (props.$isMobile ? '80px' : props.$isTablet ? '70px' : '80px')}; /* 기수 버튼과 동일한 크기 */
   text-align: left;
   background-color: #fff;
   border-radius: 8px;
@@ -115,7 +114,7 @@ export const ListContainer = styled.div<{$isTablet: boolean; $isBig: boolean;}>`
 /* 비어 있을 떄 출력하는 레이아웃 잡는 컨테이너 */
 export const DescriptionContainer = styled.div`
   width: 100%;
-  margin: 20px auto;
+  margin: 20px;
   display: block;
 `;
 
@@ -130,10 +129,15 @@ export const TextContainer = styled.div<{$isMobile: boolean;}>`
   color: black;
   font-size: ${(props) => (props.$isMobile ? "20px" : "32px")};
   font-weight: 600;
+  margin-bottom: 200px;
 
   a {
     font-size: ${(props) => (props.$isMobile ? "10px" : "14px")};
     font-weight: 300;
   }
   gap: 10px;
+`;
+
+export const Wrapper = styled.div`
+  margin-top: 100px;
 `;

--- a/src/pages/Blog/ProjectList.tsx
+++ b/src/pages/Blog/ProjectList.tsx
@@ -104,21 +104,23 @@ const ProjectList: React.FC = () => {
           )}
         </S.FilterWrapper>
       </S.TableContainer>
-
+      
       {/* 프로젝트 카드 리스트 */}
       {/* 지금은 더미데이터의 갯수로 블로그가 있는지 없는지 판단합니다. 디버깅시 projectdata.length>6 이렇게 하면 아무 것도 없는 창 뜹니다.*/}
-      {(projectData.length > 6) ? (
-      <S.ListContainer $isTablet={isTablet} $isBig={isBig}>
-        {projectData.map((item, index) => (
-          <ProjectItem key={index} {...item} />
-        ))}
-      </S.ListContainer>) : (
+      <S.Wrapper>
+        {(projectData.length > 6) ? (
+          <S.ListContainer $isTablet={isTablet} $isBig={isBig}>
+            {projectData.map((item, index) => (
+              <ProjectItem key={index} {...item} />
+            ))}
+          </S.ListContainer>
+        ) : (
           <S.TextContainer $isMobile={isMobile}>
             아직 등록된 글이 없어요.
             <a>파밍로그를 통해 글을 작성해보세요!</a>
           </S.TextContainer>
-      )
-      }
+        )}
+      </S.Wrapper>
     </S.Container>
   );
 };

--- a/src/pages/Blog/index.styles.tsx
+++ b/src/pages/Blog/index.styles.tsx
@@ -1,35 +1,53 @@
 import styled from 'styled-components';
 
-// 전체 컨테이너
 export const Container = styled.div`
   position: relative;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  min-height: 500px;
   display: flex;
+  flex-direction: column;
+  align-items: center;
   margin: 0 auto;
   padding: 0 10%;
 `;
 
-// 모양 유지 컨테이너
-export const ActiveTabIndicator = styled.div<{$isTablet: boolean; $isMobile: boolean;}>`
-  margin-top: ${(props) => (props.$isTablet ? "200px" : props.$isMobile ? "25vh" : "200px")};
-  width: 100%;
+export const ButtonWrapper = styled.div<{$isTablet: boolean; $isMobile: boolean;}>`
   display: flex;
-  font-size: ${(props) => (props.$isMobile ? "14px" : "20px")}; 
+  justify-content: flex-start;
+  width: 100%;
+  margin-top: ${(props) => (props.$isMobile ? "50px" : props.$isTablet ? "100px" : "100px")};
 `;
 
-// 버튼 컨테이너 스타일
 export const ButtonContainer = styled.div`
   width: 330px;
   height: 100px;
-  margin: 15vh 0;
-  position: absolute;
-  display: inline-flex;
+  margin-top: 10vh; 
+  display: flex;
   justify-content: left;
   gap: 5px;
+  position: relative;
 `;
 
-// 토글 버튼 스타일
+export const ContentWrapper = styled.div`
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+
+export const ActiveTabIndicator = styled.div<{$isTablet: boolean; $isMobile: boolean;}>`
+  width: 100%;
+  max-width: 1200px;
+  height: 70vh;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  font-size: ${(props) => (props.$isMobile ? "14px" : "20px")};
+`;
+
 export const ToggleButton = styled.button<{ active: boolean; $isMobile: boolean }>`
   border: none;
   background-color: transparent;
@@ -38,9 +56,9 @@ export const ToggleButton = styled.button<{ active: boolean; $isMobile: boolean 
   font-weight: 600;
   color: ${(props) => (props.active ? 'var(--FarmSystem_Green01)' : 'var(--FarmSystem_DarkGrey)')};
   width: ${(props) => (props.$isMobile ? "110px": "170px")};
-
   padding-right: 5px;
 `;
+
 export const Divider = styled.div<{ $isMobile: boolean }>`
   margin: ${(props) => (props.$isMobile ? "0px 0px 0px 0px": "0px 0px 0px 10px")};
   font-size: ${(props) => (props.$isMobile ? '30px' : '64px')};

--- a/src/pages/Blog/index.tsx
+++ b/src/pages/Blog/index.tsx
@@ -12,15 +12,17 @@ const Blog: React.FC = () => {
   return (
     <>
     <S.Container>
-      <S.ButtonContainer>
-        <S.ToggleButton active={activeTab === 'project'} onClick={() => setActiveTab('project')} $isMobile={isMobile}>
-          <div>프로젝트</div>
-        </S.ToggleButton>
-        <S.Divider $isMobile={isMobile}>|</S.Divider>
-        <S.ToggleButton active={activeTab === 'blog'} onClick={() => setActiveTab('blog')} $isMobile={isMobile}>
-          <div>블로그</div>
-        </S.ToggleButton>
-      </S.ButtonContainer>
+      <S.ButtonWrapper $isMobile={isMobile} $isTablet={isTablet}>
+        <S.ButtonContainer>
+          <S.ToggleButton active={activeTab === 'project'} onClick={() => setActiveTab('project')} $isMobile={isMobile}>
+            <div>프로젝트</div>
+          </S.ToggleButton>
+          <S.Divider $isMobile={isMobile}>|</S.Divider>
+          <S.ToggleButton active={activeTab === 'blog'} onClick={() => setActiveTab('blog')} $isMobile={isMobile}>
+            <div>블로그</div>
+          </S.ToggleButton>
+        </S.ButtonContainer>
+      </S.ButtonWrapper>
         {activeTab === 'project' && (
           <S.ActiveTabIndicator $isTablet={isTablet} $isMobile={isMobile}>
             <ProjectList />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #106 

## 📝작업 내용

> 프로젝트/블로그 페이지 분할 화면 깨짐 현상 아이템들이 화면을 넘어가면 스크롤하도록 수정했습니다.

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
![스크린샷 2025-02-28 185332](https://github.com/user-attachments/assets/dd93a5c1-4784-4f2c-a175-d1c63cd0ccdb)
