### PR TITLE
fix: apiConfig에서 env 없는 예외 처리 + api통신에서 enum 수정

### DIFF
--- a/src/config/apiConfig.ts
+++ b/src/config/apiConfig.ts
@@ -1,14 +1,22 @@
 import axios from 'axios';
 
 const getApiBaseUrl = () => {
-  // 개발 모드이거나(로컬호스트등 vite가 알아서 인식) dev.로 시작하는 도메인이면 개발 서버 주소로 설정
   const hostname = window.location.hostname;
   let baseUrl;
 
+  // 환경 변수가 없으면 경고 메시지 출력 + 하드코딩된 URL 사용
+  if (!import.meta.env.VITE_BASE_URL || !import.meta.env.VITE_BASE_DEV_URL) {
+    const warningMessage = "⚠️ 환경 변수가 누락되었습니다. 기본 URL을 사용합니다.";
+    console.warn(warningMessage);
+  }
+
+  const baseDevUrl = import.meta.env?.VITE_BASE_DEV_URL || "https://api.dev.farmsystem.kr";
+  const baseProdUrl = import.meta.env?.VITE_BASE_URL || "https://api.farmsystem.kr";
+
   if (import.meta.env.MODE === 'development' || hostname.startsWith('dev.')) {
-    baseUrl = import.meta.env.VITE_BASE_DEV_URL; // 개발 서버
+    baseUrl = baseDevUrl ;
   } else {
-    baseUrl = import.meta.env.VITE_BASE_URL; // 운영 서버
+    baseUrl = baseProdUrl;
   }
   
   // URL이 '/'로 끝나면 'api/', 아니면 '/api/'

--- a/src/models/apply.ts
+++ b/src/models/apply.ts
@@ -6,14 +6,12 @@ enum ApiErrorMessages {
   OPTION_NOT_FOUND = "선택지를 찾을 수 없습니다.",
 }
 
-// 이거 아직 다 작성 안된거임!! 
-// swagger 보고 enum 채울 예정
 export enum Track {
   UNION = "UNION",
   GAMING_VIDEO = "GAMING_VIDEO",
   AI = "AI",
-  WEB = "WEB",
-  IOT = "IOT",
+  SECURITY_WEB = "SECURITY_WEB",
+  IOT_ROBOTICS = "IOT_ROBOTICS",
   BIGDATA = "BIGDATA",
 }
 

--- a/src/pages/Apply/ApplyBox.tsx
+++ b/src/pages/Apply/ApplyBox.tsx
@@ -22,8 +22,8 @@ const TrackKorean = {
   UNION: "유니온",
   GAMING_VIDEO: "게임/영상",
   AI: "인공지능",
-  WEB: "보안/웹",
-  IOT: "사물인터넷",
+  SECURITY_WEB: "보안/웹",
+  IOT_ROBOTICS: "사물인터넷/로봇",
   BIGDATA: "빅데이터",
 } as const;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #90 

## 📝작업 내용

**api 관련 수정사항들 한번에 처리했습니다.**
- `apiConfig.ts`에서 env 없을 때 브라우져 쪽 콘솔에 경고 한번 찍고 하드코딩한 url로 통신 시도
- 기존 enum 이름을 백엔드와 일치하게 변경

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
