### PR TITLE
feat: 지원 페이지 닫기

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,8 +8,10 @@ import News from '@/pages/News';
 import NewsDetail from '@/pages/News/NewsDetail';
 import FAQ from '@/pages/FAQ';
 import MaintainPage from '@/pages/MaintainPage';
+import RedirectRoute from '@/components/RedirectRoute';
 
 const IS_MAINTENANCE = false; // 유지보수 모드 ON/OFF 설정은 여기서 해주시면 됩니다.
+const IS_RECRUIT = false; // 모집 모드 ON/OFF 설정은 여기서 해주시면 됩니다.
 
 export default function Router() {
   if (IS_MAINTENANCE) {
@@ -22,7 +24,7 @@ export default function Router() {
       element: <Layout />,
       children: [
         { path: '/', element: <Main /> },
-        { path: '/recruit', element: <Recruit /> },
+        { path: '/recruit', element: <RedirectRoute boolean={IS_RECRUIT}><Recruit /></RedirectRoute>},
         { path: '/blog', element: <Blog /> },
         { path: '/news', element: <News /> },
         { path: '/news/:newsId', element: <NewsDetail /> },

--- a/src/components/Header/Header.styled.tsx
+++ b/src/components/Header/Header.styled.tsx
@@ -77,11 +77,14 @@ export const NavItem = styled.a<{ $isMobile: boolean; $isTablet: boolean; isActi
   `}
 `;
 
-export const FarmingLogButton = styled.button`
+export const FarmingLogButton = styled.button<{ isRecruit: boolean}>`
   width: 120px;
   height: 40px;
   border-radius: 10px;
-  background-color: #28723f;
+  background-color: ${({ isRecruit }) => (isRecruit
+    ? "var(--FarmSystem_Green01, #28723f)" 
+    : "var(--FarmSystem_DarkGrey, #999999)"
+  )};
   color: white;
   font-weight: 500;
   font-size: 16px;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -140,7 +140,7 @@ export default function Header() {
         isOpen={isPopupOpen} 
         onClose={() => setPopupOpen(false)} 
         title={"지금은 모집 기간이 아니에요."} 
-        content={"3월 4일부터 지원 가능해요."} 
+        content={"3월 13일까지 지원 가능해요."} 
       />
     </S.HeaderContainer>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,6 +6,8 @@ import Hamburger from '../../assets/Icons/Hamburger.png';
 import CloseIcon from '../../assets/Icons/Close2.png';
 import useMediaQueries from '@/hooks/useMediaQueries';
 
+const IS_RECRUIT = false; // 모집 모드 ON/OFF 설정은 여기서 해주시면 됩니다.
+
 export default function Header() {
   const [isPopupOpen, setPopupOpen] = useState(false);
   const [isMenuOpen, setMenuOpen] = useState(false);
@@ -16,6 +18,14 @@ export default function Header() {
   const handleNavItemClick = (path?: string) => {
     if (path) navigate(path);
     setMenuOpen(false);
+  };
+
+  const handleRecruitClick = () => {
+    if (IS_RECRUIT) {
+      navigate('/recruit');
+    } else {
+      setPopupOpen(true);
+    }
   };
 
   return (
@@ -64,7 +74,12 @@ export default function Header() {
               </S.NavItem>
             </S.Nav>
           </S.NavWrapper>
-          <S.FarmingLogButton onClick={() => navigate('/recruit')} >지원하기</S.FarmingLogButton>
+          <S.FarmingLogButton
+            isRecruit={IS_RECRUIT}
+            onClick={handleRecruitClick}
+          >
+            지원하기
+          </S.FarmingLogButton>
         </>
       )}
 
@@ -110,8 +125,8 @@ export default function Header() {
               </S.NavItem>
               <S.NavItem 
                 $isTablet={isTablet} 
-                $isMobile={isMobile} 
-                onClick={() => handleNavItemClick('/recruit')}
+                $isMobile={isMobile}
+                onClick={handleRecruitClick}
                 isActive={false}
               >
                 지원하기

--- a/src/components/RedirectRoute.tsx
+++ b/src/components/RedirectRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from 'react-router';
+
+interface PrivateRouteProps {
+  children: JSX.Element; // 보호할 컴포넌트(페이지)
+  boolean: boolean; // 리다이렉트 여부
+}
+
+export default function PrivateRoute({ children, boolean }: PrivateRouteProps) {
+  if (!boolean) {
+    return <Navigate to="/" />;
+  }
+  return children;
+}

--- a/src/pages/Main/BottomInfo/BottomInfo.styles.ts
+++ b/src/pages/Main/BottomInfo/BottomInfo.styles.ts
@@ -81,9 +81,12 @@ export const ButtonContainer = styled.div<{ $isApp: boolean; $isMobile: boolean 
   margin-top: ${({$isApp, $isMobile }) => ($isApp ? "10px" : $isMobile ? "20px" : "40px")};
 `;
 
-export const ApplyButton = styled.button<{ $isApp: boolean; $isMobile: boolean }>`
+export const ApplyButton = styled.button<{ $isApp: boolean; $isMobile: boolean, isRecruit: boolean }>`
   width: ${({ $isApp, $isMobile }) => ($isApp ? "110px" : $isMobile ? "180px" : "240px")};
-  background-color: #49aa59;
+  background-color: ${({ isRecruit }) => (isRecruit
+    ? "var(--FarmSystem_Green04, #49aa59) "
+    : "var(--FarmSystem_DarkGrey, #999999)"
+  )};
   color: #ffffff;
   font-size: ${({ $isApp, $isMobile }) => ($isApp ? "14px" : $isMobile ? "18px" : "20px")};
   padding: 12px 24px;
@@ -92,7 +95,9 @@ export const ApplyButton = styled.button<{ $isApp: boolean; $isMobile: boolean }
   cursor: pointer;
   box-shadow: 0px 2px 10px rgba(25, 25, 25, 0.2);
   &:hover {
-    background-color: #3b8a48;
+    background-color:${({ isRecruit }) => (isRecruit
+      ? "#3b8a48" : "var(--FarmSystem_DarkGrey, #999999)"
+    )};
   }
 `;
 

--- a/src/pages/Main/BottomInfo/BottomInfo.tsx
+++ b/src/pages/Main/BottomInfo/BottomInfo.tsx
@@ -5,11 +5,20 @@ import Popup from '@/components/Popup/Popup';
 import useMediaQueries from '@/hooks/useMediaQueries';
 
 // const googleFormLink = "https://docs.google.com/forms/d/e/1FAIpQLSd1p3w5T1c1XFxM4lrqGxwCrW-L1f9Wm4bLmOmcAWcqSILpPw/viewform";
+const IS_RECRUIT = false; // 모집 중인지 여부
 
 const BottomInfo = () => {
   const navigate = useNavigate();
   const [isPopupOpen, setPopupOpen] = useState(false);
   const { isApp, isMobile, isTablet } = useMediaQueries();
+
+  const handleRecruitClick = () => {
+    if (IS_RECRUIT) {
+      navigate('/recruit');
+    } else {
+      setPopupOpen(true);
+    }
+  };
 
   return (
     <S.BottomInfoContainer id="eligibility" $isMobile={isMobile} $isTablet={isTablet}>
@@ -37,8 +46,8 @@ const BottomInfo = () => {
           <S.ApplyButton 
             $isApp={isApp}
             $isMobile={isMobile}
-            // 지원하기 url은 '/recruit'입니다!
-            onClick={() => navigate('/recruit')}
+            isRecruit={IS_RECRUIT}
+            onClick={handleRecruitClick}
           >
             지원하기
           </S.ApplyButton>
@@ -57,7 +66,7 @@ const BottomInfo = () => {
         isOpen={isPopupOpen} 
         onClose={() => setPopupOpen(false)} 
         title={"지금은 모집 기간이 아니에요."} 
-        content={"3월 4일부터 지원 가능해요."} 
+        content={"3월 13일까지 지원 가능해요."} 
       />
     </S.BottomInfoContainer>
   );

--- a/src/pages/Main/Intro/Intro.styled.tsx
+++ b/src/pages/Main/Intro/Intro.styled.tsx
@@ -177,8 +177,14 @@ export const Apply = styled.div`
     
 `;
 
-export const ApplyButton = styled.button<{ $isMobile: boolean; $isTablet: boolean }>`
-    background-color: #4CAF50;
+export const ApplyButton = styled.button<{ 
+    $isMobile: boolean, 
+    $isTablet: boolean, 
+    isRecruit: boolean 
+}>`
+    background-color: ${({ isRecruit }) => (isRecruit
+        ? "#4CAF50" : "var(--FarmSystem_DarkGrey, #999999)"
+    )};
     color: white;
     border: none;
     padding: ${({ $isMobile, $isTablet }) => ($isMobile ? "10px 50px" : $isTablet ? "12px 65px" : "15px 80px")};
@@ -189,7 +195,9 @@ export const ApplyButton = styled.button<{ $isMobile: boolean; $isTablet: boolea
     box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
     
     &:hover {
-        background-color: #388E3C;
+        background-color:${({ isRecruit }) => (isRecruit
+            ? "#388E3C" : "var(--FarmSystem_DarkGrey, #999999)"
+        )};
     }
 `;
 

--- a/src/pages/Main/Intro/Intro.tsx
+++ b/src/pages/Main/Intro/Intro.tsx
@@ -7,6 +7,8 @@ import useMediaQueries from '@/hooks/useMediaQueries';
 import { motion } from 'framer-motion';
 import IntroLogo from '../../../assets/Icons/IntroLogo.svg';
 
+const IS_RECRUIT = false; // 모집 기간 여부
+
 const Intro = () => {
   const [isPopupOpen, setPopupOpen] = useState(false);
   const { isApp, isMobile, isTablet } = useMediaQueries();
@@ -19,6 +21,14 @@ const Intro = () => {
       y: 0,
       transition: { delay: i * 0.3, duration: 0.6, ease: "easeOut" }
     }),
+  };
+
+  const handleRecruitClick = () => {
+    if (IS_RECRUIT) {
+      navigate('/recruit');
+    } else {
+      setPopupOpen(true);
+    }
   };
 
   if (isApp) {
@@ -113,7 +123,7 @@ const Intro = () => {
             transition={{ duration: 0.8, delay: 3.5, ease: "easeOut" }} 
             viewport={{ once: true }}
           >
-            <S.AppApplyButton onClick={() => navigate('/recruit')}>
+            <S.AppApplyButton onClick={handleRecruitClick}>
               지원하기
             </S.AppApplyButton>
           </motion.div>
@@ -124,7 +134,7 @@ const Intro = () => {
           isOpen={isPopupOpen} 
           onClose={() => setPopupOpen(false)} 
           title={"지금은 모집 기간이 아니에요."} 
-          content={"3월 4일부터 지원 가능해요."} 
+          content={"3월 13일까지 지원 가능해요."} 
         />
       </S.AppContainer>
     );
@@ -149,7 +159,14 @@ const Intro = () => {
       5가지 신기술 트랙을 제공하여 학습 경험을 통해 SW/AI 역량을 배양합니다.
       </S.TrackList>
       <S.Apply>
-        <S.ApplyButton $isMobile={isMobile} $isTablet={isTablet} onClick={() => navigate('/recruit')}> 지원하기 </S.ApplyButton>
+        <S.ApplyButton
+          $isMobile={isMobile}
+          $isTablet={isTablet}
+          onClick={handleRecruitClick}
+          isRecruit={IS_RECRUIT}
+        >
+          지원하기
+        </S.ApplyButton>
         <S.ApplyDescription $isMobile={isMobile}>2025년 3월 13일까지 모집 예정</S.ApplyDescription>
       </S.Apply>
 
@@ -160,7 +177,7 @@ const Intro = () => {
           isOpen={isPopupOpen} 
           onClose={() => setPopupOpen(false)}  
           title={"지금은 모집 기간이 아니에요."} 
-          content={"3월 4일부터 지원 가능해요."} 
+          content={"3월 13일까지 지원 가능해요."} 
         />
       )}
     </S.Container>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #151 

## 📝작업 내용

- `Router.tsx`, `Header.tsx`, `Intro.tsx`, `BottomInfo.tsx`에 `IS_RECRUIT` 불리언 상수 추가해서 쉽게 지원 켰다 껐다 가능
- 지원 상수 값에 따라 팝업여부, 리다이렉션 여부, 지원 버튼 색이 변함
- `RedirectRoute.tsx` 추가함, 자식으로 `JSX.Element` + 조건을 넣어주면 조건에 따라 자식 컴포넌트 렌더링 혹은 홈으로 리다이렉트 시킴 
- `RedirectRoute.tsx`로 `/recruit`감싸서 지원 페이지에 접근 못하게

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/8c75f23f-7c2a-4413-94c9-3e39787bb5c9)
![image](https://github.com/user-attachments/assets/f3944c66-92b8-4932-88d2-dc4f533de8bc)

