### PR TITLE
hotfix: 소식 없을때 뜨는 메시지 레이아웃 수정

### DIFF
--- a/src/pages/Blog/Blog/BlogList.tsx
+++ b/src/pages/Blog/Blog/BlogList.tsx
@@ -4,32 +4,38 @@ import BlogItem, { BlogItemProps, BlogCategory } from './BlogItem';
 import useMediaQueries from '@/hooks/useMediaQueries';
 
 /** 샘플용 더미 데이터 */
-const blogData: BlogItemProps[] = [
-  {
-    blogUrl: 'https://velog.io/',
-    tags: [{ category: BlogCategory.SEMINAR }],
-  },
-  {
-    blogUrl: 'https://blog.naver.com/educds/222797324049',
-    tags: [{ category: BlogCategory.PROJECT }],
-  },
-  {
-    blogUrl: 'https://blog.encrypted.gg/',
-    tags: [{ category: BlogCategory.STUDY }],
-  },
-  {
-    blogUrl: 'https://www.github.com',
-    tags: [{ category: BlogCategory.HACKATHON }],
-  },
-  {
-    blogUrl: 'https://ludeno-studying.tistory.com/82',
-    tags: [{ category: BlogCategory.REVIEW }],
-  },
-  {
-    blogUrl: 'https://toss.im/',
-    tags: [{ category: BlogCategory.LECTURE }],
-  },
-];
+let blogData: BlogItemProps[];
+// 개발 모드에서만 보이게 수정했습니다.
+if (import.meta.env.MODE === 'development' || window.location.hostname.startsWith('dev.')) {
+  blogData = [
+    {
+      blogUrl: 'https://velog.io/',
+      tags: [{ category: BlogCategory.SEMINAR }],
+    },
+    {
+      blogUrl: 'https://blog.naver.com/educds/222797324049',
+      tags: [{ category: BlogCategory.PROJECT }],
+    },
+    {
+      blogUrl: 'https://blog.encrypted.gg/',
+      tags: [{ category: BlogCategory.STUDY }],
+    },
+    {
+      blogUrl: 'https://www.github.com',
+      tags: [{ category: BlogCategory.HACKATHON }],
+    },
+    {
+      blogUrl: 'https://ludeno-studying.tistory.com/82',
+      tags: [{ category: BlogCategory.REVIEW }],
+    },
+    {
+      blogUrl: 'https://toss.im/',
+      tags: [{ category: BlogCategory.LECTURE }],
+    },
+  ];
+} else {
+  blogData = [];
+}
 
 const BlogList: React.FC = () => {
   const { isMobile, isTablet } = useMediaQueries();

--- a/src/pages/News/index.styled.ts
+++ b/src/pages/News/index.styled.ts
@@ -37,8 +37,7 @@ export const DescriptionContainer = styled.div`
   justify-content: center;
   align-items: center;
 
-  margin: 20px;
-  display: block;
+  padding: 20px;
 `;
 
 export const Message = styled.div<{$isMobile: boolean;}>`
@@ -52,12 +51,12 @@ export const Message = styled.div<{$isMobile: boolean;}>`
   font-size: ${(props) => (props.$isMobile ? "20px" : "32px")};
   font-weight: 600;
   margin-bottom: 35px; 
+`;
 
-  a {
-    font-size: ${(props) => (props.$isMobile ? "10px" : "14px")};
-    font-weight: 300;
-    margin-top: 10px; 
-  }
+export const MiniMessage = styled.p<{$isMobile: boolean;}>`
+  font-size: ${(props) => (props.$isMobile ? "10px" : "14px")};
+  font-weight: 400;
+  margin-top: 10px;
 `;
 
 export const NewsContainer = styled.div`

--- a/src/pages/News/index.tsx
+++ b/src/pages/News/index.tsx
@@ -22,6 +22,7 @@ export default function News() {
       <S.Container>
         <S.DescriptionContainer>
           <S.Message $isMobile={isMobile}>아직 등록된 소식이 없어요.</S.Message>
+          <S.MiniMessage $isMobile={isMobile}>곧 FarmSystem의 다양한 소식을 알려드릴게요!</S.MiniMessage>
         </S.DescriptionContainer>
       </S.Container>
     );
@@ -45,7 +46,7 @@ export default function News() {
       ) : (
         <S.DescriptionContainer>
           <S.Message $isMobile={isMobile}>아직 등록된 소식이 없어요.</S.Message>
-          <a>곧 FarmSystem의 다양한 소식을 알려드릴게요!</a>
+          <S.MiniMessage $isMobile={isMobile}>곧 FarmSystem의 다양한 소식을 알려드릴게요!</S.MiniMessage>
         </S.DescriptionContainer>
       )}
     </S.Container>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 소식 데이터가 없는 경우 나타나는 화면의 레이아웃 깨짐을 고쳤습니다.

### 기존
![image](https://github.com/user-attachments/assets/72a5db94-2aa5-4e44-908b-1b553517f939)

### 고친 부분
![image](https://github.com/user-attachments/assets/0ed19229-0b7e-432d-b2f6-fe4f3907e6a6)


## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
