### PR TITLE
fix: 팜 홈페이지 버튼에 파밍로그 유도 + 공통 콘텐츠 레이아웃 제작

### DIFF
--- a/apps/farminglog/src/layouts/WhiteContentContainer.styled.ts
+++ b/apps/farminglog/src/layouts/WhiteContentContainer.styled.ts
@@ -1,0 +1,71 @@
+import styled from "styled-components";
+
+
+interface ResponsiveProps {
+  $isApp?: boolean;
+  $isMobile?: boolean;
+  $isTablet?: boolean;
+  $isDesktop?: boolean;
+}
+
+export const MainContainer = styled.div<ResponsiveProps>`
+  display: flex;
+  padding: 20px 20px 100px;
+  min-height: 100vh;
+  width: 100%;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+export const ContentContainer = styled.div<ResponsiveProps>`
+  width: 100%;
+  max-width: 75rem;
+  min-height: 90vh;
+
+  padding: ${({ $isApp }) => ($isApp ? '20px 16px 0px 16px' : '0')};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ $isApp }) => ($isApp ? '0px' : '40px')};
+
+  border-radius: 5px;
+  background: var(--FarmSystem_White, #FCFCFC);
+`;
+
+
+export const ContentContainerHeader = styled.div<ResponsiveProps>`
+  width: 100%;
+  height: ${({ $isApp }) => ($isApp ? '40px' : '80px')};
+  display: grid;
+  grid-template-columns: 1fr 3fr 1fr;
+  align-items: center;
+
+  ${({ $isApp }) => !$isApp && `
+    background: var(--FarmSystem_White, #FCFCFC);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  `}
+`;
+
+export const ContentContainerTitle = styled.h1<ResponsiveProps>`
+  grid-column: 2;
+  color: #2E2E2E;
+  text-align: center;
+  font-family: "Pretendard Variable";
+  font-size: ${({ $isApp, $isMobile }) =>
+    $isApp ? '20px' :
+    $isMobile ? '28px' :
+    '36px'};
+  font-style: normal;
+  font-weight: 700;
+  line-height: 130%;
+  letter-spacing: -0.24px;
+`;
+
+export const GoBackButton = styled.button<ResponsiveProps>`
+  grid-column: 1;
+  width: ${({ $isApp }) => ($isApp ? '24px' : '35px')};
+  height: ${({ $isApp }) => ($isApp ? '24px' : '35px')};
+  flex-shrink: 0;
+  margin-left: ${({ $isApp }) => ($isApp ? '0px' : '25px')};
+`;

--- a/apps/farminglog/src/layouts/WhiteContentContainer.tsx
+++ b/apps/farminglog/src/layouts/WhiteContentContainer.tsx
@@ -9,13 +9,14 @@ import * as S from './WhiteContentContainer.styled';
 import GoBackImage from '@/assets/Icons/corner-up-left.png';
 
 interface WhiteContentContainerProps {
-  title: string;                  // 페이지 제목
+  title?: string;                  // 페이지 제목
   isContentHeaderShown?: boolean; // 콘텐츠 헤더 표시 여부
   children: React.ReactNode;
 };
 
 export default function WhiteContentContainer({
-  title,
+  title = '',
+  isContentHeaderShown = true,
   children
 }: WhiteContentContainerProps) {
   const navigate = useNavigate();
@@ -28,36 +29,38 @@ export default function WhiteContentContainer({
       $isTablet={isTablet}
       $isDesktop={isDesktop}
     >
-      <S.ContentContainerHeader
-        $isApp={isApp}
-        $isMobile={isMobile}
-        $isTablet={isTablet}
-        $isDesktop={isDesktop}
-      >
-        <S.GoBackButton
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isTablet={isTablet}
-          $isDesktop={isDesktop}
-          onClick={() => navigate(-1)}
-        >
-          <img src={GoBackImage} alt="뒤로가기" />
-        </S.GoBackButton>
-        <S.ContentContainerTitle
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isTablet={isTablet}
-          $isDesktop={isDesktop}
-        >
-          {title}
-        </S.ContentContainerTitle>
-      </S.ContentContainerHeader>
       <S.ContentContainer
         $isApp={isApp}
         $isMobile={isMobile}
         $isTablet={isTablet}
         $isDesktop={isDesktop}
       >
+        { isContentHeaderShown && (
+          <S.ContentContainerHeader
+            $isApp={isApp}
+            $isMobile={isMobile}
+            $isTablet={isTablet}
+            $isDesktop={isDesktop}
+          >
+            <S.GoBackButton
+              $isApp={isApp}
+              $isMobile={isMobile}
+              $isTablet={isTablet}
+              $isDesktop={isDesktop}
+              onClick={() => navigate(-1)}
+            >
+              <img src={GoBackImage} alt="뒤로가기" />
+            </S.GoBackButton>
+            <S.ContentContainerTitle
+              $isApp={isApp}
+              $isMobile={isMobile}
+              $isTablet={isTablet}
+              $isDesktop={isDesktop}
+            >
+              {title}
+            </S.ContentContainerTitle>
+          </S.ContentContainerHeader>
+        )}
         {children}
       </S.ContentContainer>
     </S.MainContainer>

--- a/apps/farminglog/src/layouts/WhiteContentContainer.tsx
+++ b/apps/farminglog/src/layouts/WhiteContentContainer.tsx
@@ -1,0 +1,65 @@
+/**
+ * 응원하기, 파밍로그, 랭킹, 마이페이지 등 페이지들의 흰색 콘텐츠 영역을 담당하는 컴포넌트
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router';
+import useMediaQueries from '@/hooks/useMediaQueries';
+import * as S from './WhiteContentContainer.styled';
+import GoBackImage from '@/assets/Icons/corner-up-left.png';
+
+interface WhiteContentContainerProps {
+  title: string;                  // 페이지 제목
+  isContentHeaderShown?: boolean; // 콘텐츠 헤더 표시 여부
+  children: React.ReactNode;
+};
+
+export default function WhiteContentContainer({
+  title,
+  children
+}: WhiteContentContainerProps) {
+  const navigate = useNavigate();
+  const { isApp, isMobile, isTablet, isDesktop } = useMediaQueries();
+  
+  return (
+    <S.MainContainer
+      $isApp={isApp}
+      $isMobile={isMobile}
+      $isTablet={isTablet}
+      $isDesktop={isDesktop}
+    >
+      <S.ContentContainerHeader
+        $isApp={isApp}
+        $isMobile={isMobile}
+        $isTablet={isTablet}
+        $isDesktop={isDesktop}
+      >
+        <S.GoBackButton
+          $isApp={isApp}
+          $isMobile={isMobile}
+          $isTablet={isTablet}
+          $isDesktop={isDesktop}
+          onClick={() => navigate(-1)}
+        >
+          <img src={GoBackImage} alt="뒤로가기" />
+        </S.GoBackButton>
+        <S.ContentContainerTitle
+          $isApp={isApp}
+          $isMobile={isMobile}
+          $isTablet={isTablet}
+          $isDesktop={isDesktop}
+        >
+          {title}
+        </S.ContentContainerTitle>
+      </S.ContentContainerHeader>
+      <S.ContentContainer
+        $isApp={isApp}
+        $isMobile={isMobile}
+        $isTablet={isTablet}
+        $isDesktop={isDesktop}
+      >
+        {children}
+      </S.ContentContainer>
+    </S.MainContainer>
+  );
+}

--- a/apps/farminglog/src/pages/cheer/index.tsx
+++ b/apps/farminglog/src/pages/cheer/index.tsx
@@ -7,6 +7,7 @@ import Thumb from '@/assets/home/thumbs-up.png';
 import { useCheerListQuery } from '@/services/query/useCheerListQuery';
 import { convertTagToCategory } from '@/utils/convertTagToCategory';
 import { useState } from 'react';
+import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 
 export interface CheerCardProps {
   cheer: {
@@ -29,7 +30,7 @@ export default function Cheer() {
 const { data: cheerList = [] } = useCheerListQuery();
 
   const navigate = useNavigate();
-  const { isApp, isMobile, isTablet, isDesktop } = useMediaQueries();
+  const { isApp, isMobile, isDesktop } = useMediaQueries();
 
   const [expandedCardId, setExpandedCardId] = useState<number | null>(null);
 
@@ -38,34 +39,7 @@ const { data: cheerList = [] } = useCheerListQuery();
 };
 
   return (
-    <S.CheerContainer
-      $isApp={isApp}
-      $isMobile={isMobile}
-      $isTablet={isTablet}
-      $isDesktop={isDesktop}
-    >
-      {/* 헤더 */}
-      <S.CheerContainerHeader
-        $isApp={isApp}
-        $isMobile={isMobile}
-        $isDesktop={isDesktop}
-      >
-        {/* <S.GoBackButton
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isDesktop={isDesktop}
-        >
-          <img src={GoBackImage} alt="뒤로가기" />
-        </S.GoBackButton> */}
-        <S.CheerContainerTitle
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isDesktop={isDesktop}
-        >
-          응원하기
-        </S.CheerContainerTitle>
-      </S.CheerContainerHeader>
-
+    <WhiteContentContainer title="응원하기" >
       {/* 본문 */}
       <S.CheerCardContainer
         $isApp={isApp}
@@ -111,6 +85,6 @@ const { data: cheerList = [] } = useCheerListQuery();
           alt="글쓰기"
         />
       </S.CheerWriteButton>
-    </S.CheerContainer>
+    </WhiteContentContainer>
   );
 }

--- a/apps/farminglog/src/pages/cheer/write/cheer.tsx
+++ b/apps/farminglog/src/pages/cheer/write/cheer.tsx
@@ -8,9 +8,6 @@ import { useUserInfoQuery } from '@repo/auth/services/query/useUserInfoQuery';
 import { useCheerMutation } from '@/services/mutation/useCheerMutation';
 import { useQueryClient } from '@tanstack/react-query';
 
-import GoBackImage from '@/assets/Icons/corner-up-left.png';
-import BackMobile from '@/assets/Icons/BackMobile.png';
-
 const tagMap = {
   '칭찬해요!': 'COMPLIMENT',
   '감사해요!': 'THANK',
@@ -92,16 +89,7 @@ export default function CheerMessageEditor({ searchedUser }: CheerMessageEditorP
   );
 };
   return (
-    <S.CheerContainer $isApp={isApp} $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
-      <S.CheerContainerHeader $isApp={isApp} $isMobile={isMobile} $isDesktop={isDesktop}>
-        <S.GoBackButton $isApp={isApp} $isMobile={isMobile} $isDesktop={isDesktop} onClick={() => navigate('/cheer')}>
-          <img src={isMobile ? BackMobile : GoBackImage} alt="뒤로가기" />
-        </S.GoBackButton>
-        <S.CheerContainerTitle $isApp={isApp} $isMobile={isMobile} $isDesktop={isDesktop}>
-          응원하기
-        </S.CheerContainerTitle>
-      </S.CheerContainerHeader>
-
+    <>
       <S.HeaderText $isApp={isApp} $isMobile={isMobile}>
         {searchedUser.name} 님에게
       </S.HeaderText>
@@ -151,6 +139,6 @@ export default function CheerMessageEditor({ searchedUser }: CheerMessageEditorP
           </S.SubmitButton>
         </S.ContentWrapper>
       </S.CheerCard>
-    </S.CheerContainer>
+    </>
   );
 }

--- a/apps/farminglog/src/pages/cheer/write/index.tsx
+++ b/apps/farminglog/src/pages/cheer/write/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import Search from './search';
 import Cheer from './cheer'; 
+import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 
 function Main() {
   const location = useLocation();
@@ -25,7 +26,7 @@ function Main() {
   }, [location.search]);
 
   return (
-    <div>
+    <WhiteContentContainer title="응원하기" >
       {!selectedUser ? (
         /** 아직 선택된 유저가 없으면 "검색 화면" */
         <Search onSelectUser={handleSelectUser} />
@@ -33,7 +34,7 @@ function Main() {
         /** 유저가 선택됐다면 "응원 메시지 작성 화면" */
         <Cheer searchedUser={selectedUser} />
       )}
-    </div>
+    </WhiteContentContainer>
   );
 }
 

--- a/apps/farminglog/src/pages/cheer/write/search.tsx
+++ b/apps/farminglog/src/pages/cheer/write/search.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react';
 import useMediaQueries from '@/hooks/useMediaQueries';
 import * as S from './search.styled';
-import GoBackImage from '@/assets/Icons/corner-up-left.png';
-import BackMobile from '@/assets/Icons/BackMobile.png';
 import searchIcon from '@/assets/Icons/search_icon.png';
 import { useUserSuggestQuery } from '@/services/query/useUserSuggestQuery';
 
@@ -37,7 +35,9 @@ export default function Search({ onSelectUser }: SearchProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<UserInfo[]>([]);
 
-  const { isApp, isMobile, isTablet, isDesktop } = useMediaQueries();
+  const { 
+    // isApp, 
+    isMobile, isTablet, isDesktop } = useMediaQueries();
 
   const { data } = useUserSuggestQuery(query);
 
@@ -62,36 +62,7 @@ export default function Search({ onSelectUser }: SearchProps) {
 
 
   return (
-    <S.SearchContainer
-      $isApp={isApp}
-      $isMobile={isMobile}
-      $isTablet={isTablet}
-      $isDesktop={isDesktop}
-    >
-      {/* 헤더 */}
-      <S.SearchHeader
-        $isApp={isApp}
-        $isMobile={isMobile}
-        $isDesktop={isDesktop}
-      >
-        <S.GoBackButton
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isDesktop={isDesktop}
-          onClick={() => window.history.back()}
-        >
-          <img src={isMobile ? BackMobile : GoBackImage} alt="뒤로가기" />
-        </S.GoBackButton>
-
-        <S.SearchTitle
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isDesktop={isDesktop}
-        >
-          응원하기
-        </S.SearchTitle>
-      </S.SearchHeader>
-
+    <>
       <S.Title $isMobile={isMobile}>
         응원할 회원의 <p>이름</p>을<br />
         찾아주세요!
@@ -146,6 +117,6 @@ export default function Search({ onSelectUser }: SearchProps) {
           </S.ResultsList>
         )}
       </S.SearchWrapper>
-    </S.SearchContainer>
+    </>
   );
 }

--- a/apps/farminglog/src/pages/farminglog/create/index.tsx
+++ b/apps/farminglog/src/pages/farminglog/create/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/services/mutation/FarmingLog';
 import useFarmingLogStore from '@/stores/farminglogStore';
 // import Popup from '@/components/Popup/popup';
+import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 
 import PinIcon from '@/assets/Icons/x.png';
 import Polygon from '@/assets/Icons/polygon-1.png';
@@ -31,7 +32,7 @@ export default function Editor() {
   // const [popUpText, setPopUpText] = useState<string[]>(['', '']);
 
   const navigate = useNavigate();
-  const { isApp, isMobile, isTablet, isDesktop } = useMediaQueries();
+  const { isApp, isMobile, isDesktop } = useMediaQueries();
   const { mutate: createFarmingLogMutate } = useCreateFarmingLogMutation();
   const { mutate: editFarmingLogMutate } = useEditFarmingLogMutation();
   const {
@@ -137,13 +138,9 @@ export default function Editor() {
   };
 
   return (
-    <S.MainContainer>
-      <S.FarmingLogEditorContainer
-        $isApp={isApp}
-        $isMobile={isMobile}
-        $isTablet={isTablet}
-        $isDesktop={isDesktop}
-      >
+    <WhiteContentContainer
+      isContentHeaderShown={false}
+    >
         {/* Header 섹션 */}
         <S.FarmingLogEditorContainerHeader $isApp={isApp} $isMobile={isMobile}>
           <S.HeaderPinContainer $isApp={isApp}>
@@ -252,7 +249,6 @@ export default function Editor() {
             </S.ButtonEnnerText>
           </S.CreateButton>
         </S.ButtonContainer>
-      </S.FarmingLogEditorContainer>
       {/* {popUpOpen && (
         <Popup
           isOpen={popUpOpen}
@@ -263,6 +259,6 @@ export default function Editor() {
           confirmLabel='확인'
         />
       )} */}
-    </S.MainContainer>
+    </WhiteContentContainer>
   );
 }

--- a/apps/farminglog/src/pages/farminglog/view/index.tsx
+++ b/apps/farminglog/src/pages/farminglog/view/index.tsx
@@ -3,15 +3,15 @@ import * as S from './index.styled';
 import Card from './Card';
 import { useNavigate } from 'react-router';
 import useMediaQueries from '@/hooks/useMediaQueries';
+import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 import { useFarmingLogsInfiniteQuery } from '@/services/query/useFarmingLogInfiniteQuery';
 import useFarmingLogStore from '@/stores/farminglogStore';
 
-import GoBackImage from '@/assets/Icons/corner-up-left.png';
 import EditImage from '@/assets/Icons/edit-3.png';
 
 export default function View() {
   const navigate = useNavigate();
-  const { isApp, isMobile, isTablet, isDesktop } = useMediaQueries();
+  const { isApp, isMobile, isDesktop } = useMediaQueries();
 
   const {
     data,
@@ -56,34 +56,10 @@ export default function View() {
   if (!data) return <div>데이터가 없습니다.</div>;
 
   return (
-    <S.MainContainer>
-      <S.FarmingLogContainer
-        $isApp={isApp}
-        $isMobile={isMobile}
-        $isTablet={isTablet}
-        $isDesktop={isDesktop}
+    <WhiteContentContainer
+      title="파밍로그"
+      isContentHeaderShown={true}
       >
-        <S.FarmingLogContainerHeader
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isDesktop={isDesktop}
-        >
-          <S.GoBackButton
-            $isApp={isApp}
-            $isMobile={isMobile}
-            $isDesktop={isDesktop}
-            onClick={() => navigate(-1)}
-          >
-            <img src={GoBackImage} alt="뒤로가기" />
-          </S.GoBackButton>
-          <S.FarmingLogContainerTitle
-            $isApp={isApp}
-            $isMobile={isMobile}
-            $isDesktop={isDesktop}
-          >
-            파밍 로그
-          </S.FarmingLogContainerTitle>
-        </S.FarmingLogContainerHeader>
         <S.FarmingLogCardContainer
           $isApp={isApp}
           $isMobile={isMobile}
@@ -134,7 +110,6 @@ export default function View() {
             alt="글쓰기"
           />
         </S.FarmingLogWriteButton>
-      </S.FarmingLogContainer>
-    </S.MainContainer>
+    </WhiteContentContainer>
   );
 }

--- a/apps/farminglog/src/pages/myPage/WebView/WebView.tsx
+++ b/apps/farminglog/src/pages/myPage/WebView/WebView.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState, useRef } from 'react';
-import { useNavigate } from 'react-router';
+// import { useNavigate } from 'react-router';
 import * as S from './WebView.styles';
 import useMediaQueries from '@/hooks/useMediaQueries';
+import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 
-import BackArrow from '@/assets/Icons/BackArrow.png';
+// import BackArrow from '@/assets/Icons/BackArrow.png';
 import NotionIcon from '@/assets/Icons/Notion.png';
 import GithubIcon from '@/assets/Icons/Github.png';
 import PhoneIcon from '@/assets/Icons/PhoneIcon.png';
@@ -14,8 +15,9 @@ import { useUserInfoQuery } from '@repo/auth/services/query/useUserInfoQuery';
 import { useUpdateUserMutation } from '@repo/auth/services/mutation/useUpdateUserMutation';
 // import { useUserStore } from '@repo/auth/stores/userStore';
 
+
 export default function WebView() {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
   const { isMobile } = useMediaQueries();
   const { data: user } = useUserInfoQuery();  // , refetch
   const { mutate: updateUserInfo } = useUpdateUserMutation();
@@ -82,16 +84,18 @@ const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
   ];
 
   return (
-    <S.MyPageContainer>
-      <S.ProfileWrapper isMobile={isMobile}>
-        <S.TitleBox isMobile={isMobile}>
-          <S.BackArrow src={BackArrow} onClick={() => navigate(-1)}/>
-          <S.Title>마이페이지</S.Title>
-          <S.EditButton onClick={isEditing ? handleEditComplete : () => setIsEditing(true)}>
+    <WhiteContentContainer title="마이페이지">
+    {/* <S.MyPageContainer>
+         <S.ProfileWrapper isMobile={isMobile}>
+           <S.TitleBox isMobile={isMobile}>
+             <S.BackArrow src={BackArrow} onClick={() => navigate(-1)}/>
+             <S.Title>마이페이지</S.Title>
+          
+           </S.TitleBox> */}
+
+        <S.EditButton onClick={isEditing ? handleEditComplete : () => setIsEditing(true)}>
             {isEditing ? '완료' : '수정하기'}
           </S.EditButton>
-        </S.TitleBox>
-
         <S.SectionTitleBox isMobile={isMobile}>
           <S.SectionTitle>프로필</S.SectionTitle>
         </S.SectionTitleBox>
@@ -173,7 +177,8 @@ const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
             </S.AccountLinks>
           </>
         )}
-      </S.ProfileWrapper>
-    </S.MyPageContainer>
+      {/* </S.ProfileWrapper>
+    </S.MyPageContainer> */}
+    </WhiteContentContainer>
   );
 }

--- a/apps/farminglog/src/pages/ranking/index.tsx
+++ b/apps/farminglog/src/pages/ranking/index.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router';
 import { AnimatePresence } from 'framer-motion';
 import * as S from './index.styles';
 import useMediaQueries from '@/hooks/useMediaQueries';
-import BackArrow from '../../assets/Icons/BackArrow.png';
 import FarmLogo from '../../assets/Icons/FarmSystem_Logo.png';
 import Crown from '../../assets/Icons/crown.png';
 import Sign from '@/components/Ranking/sign';
@@ -11,6 +10,7 @@ import CheerBalloon from './components/CheerBalloon';
 import { useUserRankingQuery } from '@/services/query/useUserRankingQuery';
 import { convertTrackToString } from '@/utils/convertTrackToString';
 import ProfilePopup from '@/components/Popup/ProfilePopup';
+import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 
 const headerTexts = [
   '랭킹은 씨앗을 기준으로 0시간마다 정렬돼요.',
@@ -21,7 +21,7 @@ const headerTexts = [
 export default function Main() {
   const navigate = useNavigate();
   const { data, isLoading } = useUserRankingQuery();
-  const { isDesktop, isMobile, isApp } = useMediaQueries();
+  const { isMobile, isApp } = useMediaQueries();
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [balloonPosition, setBalloonPosition] = useState<{ x: number; y: number } | null>(null);
   const [showProfilePopup, setShowProfilePopup] = useState(false);
@@ -51,29 +51,7 @@ export default function Main() {
   const rankingData = [data.myRank, ...data.userRankList].filter(item => item !== null);
 
   return (
-    <S.MyPageContainer>
-      <S.ProfileWrapper $isApp={isApp} $isMobile={isMobile} $isDesktop={isDesktop}>
-        <S.FarmingLogContainerHeader
-          $isApp={isApp}
-          $isMobile={isMobile}
-          $isDesktop={isDesktop}
-        >
-          <S.GoBackButton
-            $isApp={isApp}
-            $isMobile={isMobile}
-            $isDesktop={isDesktop}
-            onClick={() => navigate(-1)}
-          >
-            <img src={BackArrow} alt="뒤로가기" />
-          </S.GoBackButton>
-          <S.FarmingLogContainerTitle
-            $isApp={isApp}
-            $isMobile={isMobile}
-            $isDesktop={isDesktop}
-          >
-            랭킹
-          </S.FarmingLogContainerTitle>
-        </S.FarmingLogContainerHeader>
+    <WhiteContentContainer title='랭킹' >
 
         <Sign isApp={isApp} isMobile={isMobile} texts={headerTexts} />
 
@@ -148,7 +126,6 @@ export default function Main() {
             onClose={() => setShowProfilePopup(false)}
           />
         )}
-      </S.ProfileWrapper>
-    </S.MyPageContainer>
+      </WhiteContentContainer>
   );
 }

--- a/apps/website/src/components/Header/Header.tsx
+++ b/apps/website/src/components/Header/Header.tsx
@@ -7,6 +7,8 @@ import CloseIcon from '../../assets/Icons/Close2.png';
 import useMediaQueries from '@/hooks/useMediaQueries';
 
 const IS_RECRUIT = false; // 모집 모드 ON/OFF 설정은 여기서 해주시면 됩니다.
+const IS_ENABLE_FARMING_LOG_BUTTON = true; // 파밍로그 버튼 활성화 여부 설정은 여기서 해주시면 됩니다.
+// 파밍로그 버튼 활성화 시 지원하기 버튼이 안보입니다.
 
 export default function Header() {
   const [isPopupOpen, setPopupOpen] = useState(false);
@@ -75,12 +77,20 @@ export default function Header() {
               </S.NavItem>
             </S.Nav>
           </S.NavWrapper>
-          <S.FarmingLogButton
-            isRecruit={IS_RECRUIT}
-            onClick={handleRecruitClick}
-          >
-            지원하기
-          </S.FarmingLogButton>
+          { IS_ENABLE_FARMING_LOG_BUTTON ? (
+            <S.FarmingLogButton
+              isRecruit={true}
+            >
+              <a href='https://farminglog.farmsystem.kr'>파밍로그</a>
+            </S.FarmingLogButton>
+          ) : (
+            <S.FarmingLogButton
+              isRecruit={IS_RECRUIT}
+              onClick={handleRecruitClick}
+            >
+              지원하기
+            </S.FarmingLogButton>
+          )}
         </>
       )}
 
@@ -124,14 +134,24 @@ export default function Header() {
               >
                 FAQ
               </S.NavItem>
-              <S.NavItem 
-                $isTablet={isTablet} 
-                $isMobile={isMobile}
-                onClick={handleRecruitClick}
-                isActive={false}
-              >
-                지원하기
-              </S.NavItem>
+              { IS_ENABLE_FARMING_LOG_BUTTON ? (
+                <S.NavItem 
+                  $isTablet={isTablet} 
+                  $isMobile={isMobile}
+                  isActive={false}
+                >
+                  <a href='https://farminglog.farmsystem.kr'>파밍로그</a>
+                </S.NavItem>
+              ) : (
+                <S.NavItem 
+                  $isTablet={isTablet} 
+                  $isMobile={isMobile}
+                  onClick={handleRecruitClick}
+                  isActive={false}
+                >
+                  지원하기
+                </S.NavItem>
+            )}
             </S.MobileNav>
           </>
         )}


### PR DESCRIPTION
## #️⃣연관된 이슈
 - #230 
 - 브랜치명과 이슈 코드 다른점 죄송합니당... 헷갈려서 기존 브랜치에 작업했었네요

## 📝작업 내용
- 상단바 지원하기 버튼 자리에 파밍로그 버튼을 추가했고, `boolean`으로 보이고 안보이게 만들었습니다.
- 공통 레이아웃 제작 후 응원하기, 파밍로그, 랭킹, 마이페이지에 적용했습니다.
    - `layouts/` 디렉토리를 생성했습니다.
    - 내부 꺠짐이 있을 수 있으니 맡으신 페이지 한번씩 검토 부탁드립니다!
    - 흰색 콘텐츠 컨테이너가 피그마랑 다른 점이 있으면 편하게 수정해주세요. 작업하기 전에 빨리 만들어야 할 것 같아 아직 그부분 검토를 안했습니다.
    - 다만, 마이페이지는 레이아웃이 깨져 준형님이 한번 수정 해주시면 좋을거 같습니다 @parkjoohyung0826 
    - 마이페이지 앱뷰는 안건들였습니다!

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
<img width="1710" alt="스크린샷 2025-04-04 오전 1 50 48" src="https://github.com/user-attachments/assets/a857b115-e675-4f30-a12f-c3d3e272cae5" />

<img width="1710" alt="스크린샷 2025-04-04 오전 1 29 16" src="https://github.com/user-attachments/assets/2d1848e3-5259-4a2f-87f8-76e611c9cdc0" />

<img width="1710" alt="스크린샷 2025-04-04 오전 1 41 17" src="https://github.com/user-attachments/assets/32727307-4f35-4b70-ab53-b7cd9f4a2485" />

