### PR TITLE
fix: 파밍로그 페이지 트러블 슈팅 찐찐막

### DIFF
--- a/apps/farminglog/src/pages/farminglog/create/index.tsx
+++ b/apps/farminglog/src/pages/farminglog/create/index.tsx
@@ -148,16 +148,16 @@ export default function Editor() {
     setIsDropDownOpen((prev) => !prev);
   };
 
-  const getCurrentTimeFormatedString = () => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const hours = String(now.getHours()).padStart(2, '0');
-    const minutes = String(now.getMinutes()).padStart(2, '0');
+  // const getCurrentTimeFormatedString = () => {
+  //   const now = new Date();
+  //   const year = now.getFullYear();
+  //   const month = String(now.getMonth() + 1).padStart(2, '0');
+  //   const day = String(now.getDate()).padStart(2, '0');
+  //   const hours = String(now.getHours()).padStart(2, '0');
+  //   const minutes = String(now.getMinutes()).padStart(2, '0');
 
-    return `${year}/${month}/${day} ${hours}:${minutes}`;
-  };
+  //   return `${year}/${month}/${day} ${hours}:${minutes}`;
+  // };
 
   return (
     <WhiteContentContainer isContentHeaderShown={false}>
@@ -228,11 +228,11 @@ export default function Editor() {
           </S.InputAndTextContainer>
 
           {/* 날짜 */}
-          {isApp && (
+          {/* {isApp && (
             <S.DateContainer>
               <S.DateText>{getCurrentTimeFormatedString()}</S.DateText>
             </S.DateContainer>
-          )}
+          )} */}
 
           {/* 내용 */}
           <S.InputAndTextContainer $isApp={isApp}>

--- a/apps/farminglog/src/pages/farminglog/create/index.tsx
+++ b/apps/farminglog/src/pages/farminglog/create/index.tsx
@@ -85,9 +85,15 @@ export default function Editor() {
 
     const categoryEnum = FarmingLogCategory[dropDownSelected];
 
-    if (titleCount < 1 || titleCount > MAX_TITLE_LENGTH) {
+    if (titleCount < 1) {
       setPopupOpen(true);
-      setPopupMessage({ main: '제목이 너무 길어요.', sub: `1자 이상, ${MAX_TITLE_LENGTH}자 이하로 작성해주세요.` });
+      setPopupMessage({ main: '제목이 너무 짧아요.', sub: `1자 이상 작성해주세요.` });
+      return;
+    }
+
+    if (titleCount > MAX_TITLE_LENGTH) {
+      setPopupOpen(true);
+      setPopupMessage({ main: '제목이 너무 길어요.', sub: `${MAX_TITLE_LENGTH}자 이하로 작성해주세요.` });
       return;
     }
 
@@ -217,6 +223,7 @@ export default function Editor() {
               placeholder="내용을 입력해주세요."
               $isApp={isApp}
               $isMobile={isMobile}
+              maxLength={MAX_TITLE_LENGTH}
             />
           </S.InputAndTextContainer>
 
@@ -245,6 +252,7 @@ export default function Editor() {
               placeholder="내용을 입력해주세요."
               $isApp={isApp}
               $isMobile={isMobile}
+              maxLength={MAX_CONTENT_LENGTH}
             />
           </S.InputAndTextContainer>
         </S.ContentContainer>

--- a/apps/farminglog/src/pages/farminglog/view/Card.styled.ts
+++ b/apps/farminglog/src/pages/farminglog/view/Card.styled.ts
@@ -190,6 +190,7 @@ export const Author = styled.span<ResponsiveProps>`
 
 export const Content = styled.p<ResponsiveProps>`
   width: 100%;
+  max-width: 790px;
   min-height: 60px;
   white-space: normal;
   overflow-wrap: break-word;  /* 긴 단어를 적절히 나눔 */

--- a/apps/farminglog/src/pages/farminglog/view/CardSkeleton.styled.ts
+++ b/apps/farminglog/src/pages/farminglog/view/CardSkeleton.styled.ts
@@ -1,0 +1,82 @@
+import styled, { css } from "styled-components";
+
+interface ResponsiveProps {
+  $isApp?: boolean;
+  $isMobile?: boolean;
+  $isDesktop?: boolean;
+}
+
+/* 
+  skeletonStyle: 텍스트나 이미지를 숨기고 회색 박스 형태로 표시하기 위한 기본 스타일
+*/
+const skeletonStyle = css`
+  background: #e0e0e0;
+  color: transparent;
+  border-radius: 4px;
+`;
+
+/* 태그 (Category) */
+export const SkeletonCategory = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  width: 80px;
+  height: 28px;
+`;
+
+/* 수정 버튼 (EditButton) */
+export const SkeletonEditButton = styled.div`
+  ${skeletonStyle};
+  width: 24px;
+  height: 24px;
+`;
+
+/* 제목 (Title) */
+export const SkeletonTitle = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  width: 60%;
+  height: 24px;
+`;
+
+/* 좋아요 이미지 (LikeImage) */
+export const SkeletonLikeImage = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  width: ${({ $isApp, $isMobile }) =>
+    $isApp ? "20px" : $isMobile ? "25px" : "30px"};
+  height: ${({ $isApp, $isMobile }) =>
+    $isApp ? "20px" : $isMobile ? "25px" : "30px"};
+  border-radius: 50%;
+`;
+
+/* 좋아요 카운트 (LikeCount) */
+export const SkeletonLikeCount = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  width: 20px;
+  height: 10px;
+`;
+
+/* 작성일 (CreatedAt) */
+export const SkeletonCreatedAt = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  flex: 1;
+  height: 16px;
+`;
+
+/* 작성자 (Author) */
+export const SkeletonAuthor = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  flex: 1;
+  height: 16px;
+`;
+
+/* 내용 (Content) */
+export const SkeletonContent = styled.div<ResponsiveProps>`
+  ${skeletonStyle};
+  width: 100%;
+  min-height: 60px;
+`;
+
+/* 더보기 버튼 (DetailButton) */
+export const SkeletonDetailButton = styled.div`
+  ${skeletonStyle};
+  width: 60px;
+  height: 20px;
+`;

--- a/apps/farminglog/src/pages/farminglog/view/CardSkeleton.tsx
+++ b/apps/farminglog/src/pages/farminglog/view/CardSkeleton.tsx
@@ -1,0 +1,86 @@
+import * as S from "./CardSkeleton.styled";
+import useMediaQueries from "@/hooks/useMediaQueries";
+
+export default function CardSkeleton() {
+  const { isApp, isMobile } = useMediaQueries();
+  return (
+    <div
+      style={{
+        width: "100%",
+        maxWidth: "800px",
+        padding: "15px 12px 0px 13px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "30px",
+        backgroundColor: "#FCFCFC",
+        border: "2px solid #e0e0e0",
+        borderRadius: "5px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignSelf: "stretch",
+          padding: "10px 5px",
+          gap: isApp ? "5px" : "15px",
+        }}
+      >
+        {/* 상단: 태그와 수정 버튼 */}
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+            justifyContent: "space-between",
+          }}
+        >
+          <S.SkeletonCategory $isApp={isApp} $isMobile={isMobile} />
+          <S.SkeletonEditButton />
+        </div>
+        {/* 제목과 좋아요 영역 */}
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: "5px",
+          }}
+        >
+          <S.SkeletonTitle $isApp={isApp} $isMobile={isMobile} />
+          <div style={{ display: "flex", flexDirection: "column", gap: "5px", alignItems: "center" }}>
+            <S.SkeletonLikeImage $isApp={isApp} $isMobile={isMobile} />
+            <S.SkeletonLikeCount $isApp={isApp} $isMobile={isMobile} />
+          </div>
+        </div>
+        {/* 작성일과 작성자 영역 */}
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+            gap: "10px",
+            alignItems: "center",
+          }}
+        >
+          <S.SkeletonCreatedAt $isApp={isApp} $isMobile={isMobile} />
+          <S.SkeletonAuthor $isApp={isApp} $isMobile={isMobile} />
+        </div>
+        {/* 내용 */}
+        <S.SkeletonContent $isApp={isApp} $isMobile={isMobile} />
+      </div>
+      {/* 하단: 더보기 버튼 */}
+      <div
+        style={{
+          display: "flex",
+          width: "100%",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          height: "20px",
+        }}
+      >
+        <S.SkeletonDetailButton />
+      </div>
+    </div>
+  );
+}

--- a/apps/farminglog/src/pages/farminglog/view/index.styled.ts
+++ b/apps/farminglog/src/pages/farminglog/view/index.styled.ts
@@ -69,8 +69,11 @@ export const GoBackButton = styled.button<ResponsiveProps>`
 `;
 
 export const FarmingLogCardContainer = styled.div<ResponsiveProps>`
+  width : 100%;
+  max-width: 800px;
   display: flex;
   flex-direction: column;
+
   gap: 20px;
   padding: ${({ $isApp }) => ($isApp ?  '0' : '0 20px 0 20px')};
 `;

--- a/apps/farminglog/src/pages/farminglog/view/index.tsx
+++ b/apps/farminglog/src/pages/farminglog/view/index.tsx
@@ -51,7 +51,20 @@ export default function View() {
   );
 
   // 로딩 또는 에러 상태 처리
-  if (isLoading) return <div>로딩중...</div>;
+  if (isLoading) return (
+    <WhiteContentContainer
+      title="파밍로그"
+      isContentHeaderShown={true}
+    >
+      <S.FarmingLogCardContainer
+        $isApp={isApp}
+        $isMobile={isMobile}
+        $isDesktop={isDesktop}
+      >
+        <div></div>
+      </S.FarmingLogCardContainer>
+    </WhiteContentContainer>
+  );
   if (error) return <div>에러 발생: {error.message}</div>;
   if (!data) return <div>데이터가 없습니다.</div>;
 

--- a/apps/farminglog/src/pages/farminglog/view/index.tsx
+++ b/apps/farminglog/src/pages/farminglog/view/index.tsx
@@ -6,6 +6,7 @@ import useMediaQueries from '@/hooks/useMediaQueries';
 import WhiteContentContainer from '@/layouts/WhiteContentContainer';
 import { useFarmingLogsInfiniteQuery } from '@/services/query/useFarmingLogInfiniteQuery';
 import useFarmingLogStore from '@/stores/farminglogStore';
+import CardSkeleton from './CardSkeleton';
 
 import EditImage from '@/assets/Icons/edit-3.png';
 
@@ -30,8 +31,7 @@ export default function View() {
       refetch();
       setIsNeedRefresh(false);
     }
-  }
-  , [isNeedRefresh, refetch, setIsNeedRefresh]);
+  }, [isNeedRefresh, refetch, setIsNeedRefresh]);
 
   // 마지막 카드 요소를 관찰하여 다음 페이지를 불러오기 위한 IntersectionObserver
   const observerRef = useRef<IntersectionObserver | null>(null);
@@ -61,7 +61,9 @@ export default function View() {
         $isMobile={isMobile}
         $isDesktop={isDesktop}
       >
-        <div></div>
+        {Array.from({ length: 10 }, (_, index) => (
+          <CardSkeleton key={index} />
+        ))}
       </S.FarmingLogCardContainer>
     </WhiteContentContainer>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

- #255 

## 📝작업 내용

- textarea 글자 제한 걸기 [노션](https://noble-bracket-4fc.notion.site/19d9942899d98065a656f011b49964c8?v=19d9942899d98181804c000c91a2dd5e&p=1cc9942899d9809294f6eb119293e777&pm=s)
- 파밍로그 로딩창 대신 Skeleton UI [노션](https://www.notion.so/1cc9942899d98051b510fa3169864057)
- 파밍로그 시간 삭제 [노션](https://noble-bracket-4fc.notion.site/1cc9942899d98015841acd1b5f428b85?pvs=4)
- 파밍로그 제목 짧을때 멘트 수정

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e1c73453-869c-4bd9-a3e0-9db383d6da27)
